### PR TITLE
fixed bug with components calling start twice

### DIFF
--- a/Runtime/Components/AnalyticsComponentBase.cs
+++ b/Runtime/Components/AnalyticsComponentBase.cs
@@ -7,25 +7,37 @@ using UnityEditor;
 
 /// <summary>
 /// base for Cognitive3D analytics components
+/// handles delay if components are enabled before session start, enabled late and sequential session in one game instance
 /// </summary>
 
 namespace Cognitive3D.Components
 {
     public abstract class AnalyticsComponentBase : MonoBehaviour
     {
-        protected void Start()
+        /// <summary>
+        /// subscribes to Cognitive3D_Manager.OnSessionBegin and calls OnSessionBegin() if a session is currently active
+        /// </summary>
+        protected virtual void OnEnable()
         {
+            Cognitive3D_Manager.OnSessionBegin += OnSessionBegin;
+
             //if this component is enabled late, run startup as if session just began
             if (Cognitive3D_Manager.IsInitialized)
-                Cognitive3D_Init();
+                OnSessionBegin();
         }
 
         /// <summary>
-        /// called as the last step of the Cognitive3D session begin process OR on start if Cognitive3D Manager has already been initialized
+        /// use this to initialize values, start functions, etc
+        /// add any needed callbacks here
         /// </summary>
-        public virtual void Cognitive3D_Init()
+        protected virtual void OnSessionBegin()
         {
             
+        }
+
+        protected virtual void OnDisable()
+        {
+            Cognitive3D_Manager.OnSessionBegin -= OnSessionBegin;
         }
 
         //Cognitive3D Component Setup uses reflection to find these Methods. These help display each component, but are not required

--- a/Runtime/Components/ArmLength.cs
+++ b/Runtime/Components/ArmLength.cs
@@ -27,7 +27,7 @@ namespace Cognitive3D.Components
 
         Transform tempInfo = null;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
             StartCoroutine(Tick());
         }

--- a/Runtime/Components/BatteryLevel.cs
+++ b/Runtime/Components/BatteryLevel.cs
@@ -19,11 +19,11 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Battery Level")]
     public class BatteryLevel : AnalyticsComponentBase
     {
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             SendBatteryLevel();
-            Cognitive3D_Manager.OnQuit += Cognitive3D_Manager_OnQuit;
+            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnQuit;
         }
 
         void Cognitive3D_Manager_OnQuit()
@@ -61,7 +61,7 @@ namespace Cognitive3D.Components
 
         void OnDestroy()
         {
-            Cognitive3D_Manager.OnQuit -= Cognitive3D_Manager_OnQuit;
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnQuit;
         }
     }
 }

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -17,12 +17,10 @@ namespace Cognitive3D.Components
     public class BoundaryEvent : AnalyticsComponentBase
     {
 #if C3D_STEAMVR2
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
-
-
 
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsHidden).AddListener(OnChaperoneChanged);
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsShown).AddListener(OnChaperoneChanged);
@@ -30,7 +28,6 @@ namespace Cognitive3D.Components
             if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
             {
                 new CustomEvent("cvr.boundary").Send();
-                Util.logDebug("chaperone visible INITIAL STATE");
             }
         }
 
@@ -39,12 +36,10 @@ namespace Cognitive3D.Components
             if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
             {
                 new CustomEvent("cvr.boundary").SetProperty("visible", true).Send();
-                Util.logDebug("chaperone visible");
             }
             else
             {
                 new CustomEvent("cvr.boundary").SetProperty("visible", false).Send();
-                Util.logDebug("chaperone hidden");
             }
         }
 

--- a/Runtime/Components/Comfort.cs
+++ b/Runtime/Components/Comfort.cs
@@ -26,9 +26,9 @@ namespace Cognitive3D.Components
         [Tooltip("Falling below and rising above this threshold will send events")]
         public int LowFramerateThreshold = 60;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             timeleft = ComfortTrackingInterval;
             if (GameplayReferences.HMD != null)

--- a/Runtime/Components/ControllerCollisionEvent.cs
+++ b/Runtime/Components/ControllerCollisionEvent.cs
@@ -16,9 +16,9 @@ namespace Cognitive3D.Components
         
         public LayerMask CollisionLayerMask = 1;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
         }
 

--- a/Runtime/Components/ControllerInputTracker.cs
+++ b/Runtime/Components/ControllerInputTracker.cs
@@ -22,7 +22,7 @@ namespace Cognitive3D.Components
         DynamicObject LeftHand;
         DynamicObject RightHand;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
             InputDevice device;
             if (!GameplayReferences.GetControllerInfo(true, out device))
@@ -42,7 +42,7 @@ namespace Cognitive3D.Components
         void DelayEnable(InputDevice device, XRNode node, bool isValid)
         {
             GameplayReferences.OnControllerValidityChange -= DelayEnable;
-            Cognitive3D_Init();
+            OnSessionBegin();
         }
 
 #if C3D_STEAMVR2

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -15,10 +15,9 @@ namespace Cognitive3D.Components
         [Tooltip("Number of seconds used to average to determine framerate. Lower means more smaller samples and more detail")]
         public float FramerateTrackingInterval = 1;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            //if (initError != Error.None) { return; }
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
 #if XRPF
             if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete)
 #endif            

--- a/Runtime/Components/HMDCollisionEvent.cs
+++ b/Runtime/Components/HMDCollisionEvent.cs
@@ -14,9 +14,9 @@ namespace Cognitive3D.Components
         public LayerMask CollisionLayerMask = 1;
 
         bool HMDColliding;
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
         }
 

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -28,9 +28,9 @@ namespace Cognitive3D.Components
 
         float[] heights;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
 
             heights = new float[SampleCount];
 

--- a/Runtime/Components/OcclusionEvent.cs
+++ b/Runtime/Components/OcclusionEvent.cs
@@ -11,7 +11,7 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Occlusion Event")]
     public class OcclusionEvent : AnalyticsComponentBase
     {
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
             GameplayReferences.OnControllerValidityChange += GameplayReferences_OnControllerValidityChange;
             Cognitive3D_Manager.OnPostSessionEnd += Cognitive3D_Manager_OnPostSessionEnd;

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -15,9 +15,9 @@ namespace Cognitive3D.Components
         [SerializeField]
         private bool RecordPartySize = true;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
 #if C3D_OCULUS
             if (!Oculus.Platform.Core.IsInitialized())
             {

--- a/Runtime/Components/RecenterEvent.cs
+++ b/Runtime/Components/RecenterEvent.cs
@@ -13,9 +13,9 @@ namespace Cognitive3D.Components
     public class RecenterEvent : AnalyticsComponentBase
     {
 #if C3D_OCULUS
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             if (OVRManager.display != null)
                 OVRManager.display.RecenteredPose += RecenterEventTracker_RecenteredPose;
         }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -11,9 +11,9 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Room Size")]
     public class RoomSize : AnalyticsComponentBase
     {
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
 
             Vector3 roomsize = new Vector3();
             if (GameplayReferences.GetRoomSize(ref roomsize))

--- a/Runtime/Components/ScreenResolution.cs
+++ b/Runtime/Components/ScreenResolution.cs
@@ -11,9 +11,9 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Screen Resolution")]
     public class ScreenResolution : AnalyticsComponentBase
     {
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             Cognitive3D_Manager.SetSessionProperty("c3d.device.screenresolution", Screen.height + " x " + Screen.width);
         }
 

--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -24,9 +24,9 @@ namespace Cognitive3D.Components
 
         Vector3 lastRootPosition;
 
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             lastRootPosition = root.position;
         }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -206,12 +206,6 @@ namespace Cognitive3D
             StartCoroutine(Tick());
             Util.logDebug("Cognitive3D Initialized");
 
-            var components = GetComponentsInChildren<Cognitive3D.Components.AnalyticsComponentBase>();
-            for (int i = 0; i < components.Length; i++)
-            {
-                components[i].Cognitive3D_Init();
-            }
-
             //TODO support for 360 skysphere media recording
             gazeBase = gameObject.GetComponent<PhysicsGaze>();
             if (gazeBase == null)

--- a/Runtime/Scripts/GPSLocation.cs
+++ b/Runtime/Scripts/GPSLocation.cs
@@ -13,9 +13,9 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/GPS Location")]
     public class GPSLocation : Cognitive3D.Components.AnalyticsComponentBase
     {
-        public override void Cognitive3D_Init()
+        protected override void OnSessionBegin()
         {
-            base.Cognitive3D_Init();
+            base.OnSessionBegin();
 
             //loop until TryGetGPSLocation returns true
             StartCoroutine(GPSBegin());


### PR DESCRIPTION
# Description

Made components that inherit from Analytics Component Base subscribe to the OnSessionBegin event in OnEnable, and removed initialize call from Cognitive Manager. Should work more consistently for strange startup orders and sequential sessions.

Height Task ID (If applicable):

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules