### PR TITLE
Developer controlled sending battery level on start and pause

### DIFF
--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -208,7 +208,7 @@ namespace Cognitive3D
             if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
 #endif
             {
-                if (SendBatteryLevelOnStartAndEnd) { startEvent.SetProperty("Battery Level", SystemInfo.batteryLevel * 100); }
+                if (SendBatteryLevelOnStartAndEnd) { startEvent.SetProperty("HMD Battery Level", SystemInfo.batteryLevel * 100); }
             }
             startEvent.Send();
             playerSnapshotInverval = new WaitForSeconds(Cognitive3D_Preferences.SnapshotInterval);
@@ -481,7 +481,7 @@ namespace Cognitive3D
             if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
 #endif
             {
-                if (SendBatteryLevelOnStartAndEnd) { pauseEvent.SetProperty("Battery Level", SystemInfo.batteryLevel * 100); }
+                if (SendBatteryLevelOnStartAndEnd) { pauseEvent.SetProperty("HMD Battery Level", SystemInfo.batteryLevel * 100); }
             }
             pauseEvent.Send();
             FlushData();

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -58,6 +58,9 @@ namespace Cognitive3D
         [Tooltip("Delay before starting a session. This delay can ensure other SDKs have properly initialized")]
         public float StartupDelayTime = 0;
 
+        [Tooltip("Send HMD Battery Level on the Start and End of the application")]
+        public bool SendBatteryLevelOnStartAndEnd;
+
         /// <summary>
         /// sets instance of Cognitive3D_Manager
         /// </summary>
@@ -200,7 +203,14 @@ namespace Cognitive3D
 
             InvokeLevelLoadedEvent(scene, UnityEngine.SceneManagement.LoadSceneMode.Single, true);
 
-            new CustomEvent("c3d.sessionStart").Send();
+            CustomEvent startEvent = new CustomEvent("c3d.sessionStart");
+#if XRPF
+            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
+#endif
+            {
+                if (SendBatteryLevelOnStartAndEnd) { startEvent.SetProperty("Battery Level", SystemInfo.batteryLevel * 100); }
+            }
+            startEvent.Send();
             playerSnapshotInverval = new WaitForSeconds(Cognitive3D_Preferences.SnapshotInterval);
             automaticSendInterval = new WaitForSeconds(Cognitive3D_Preferences.Instance.AutomaticSendTimer);
             StartCoroutine(Tick());
@@ -466,7 +476,14 @@ namespace Cognitive3D
             }
 #endif
             if (!IsInitialized) { return; }
-            new CustomEvent("c3d.pause").SetProperty("is paused", paused).Send();  
+            CustomEvent pauseEvent = new CustomEvent("c3d.pause").SetProperty("ispaused", paused);
+#if XRPF
+            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
+#endif
+            {
+                if (SendBatteryLevelOnStartAndEnd) { pauseEvent.SetProperty("Battery Level", SystemInfo.batteryLevel * 100); }
+            }
+            pauseEvent.Send();
             FlushData();
         }
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

We are sending battery level (if XRPF approved) on session start and session pause events. We can't yet determine end session properly, so we might have to either do backend magic or some plugin work to determine when the session ends.

Please use "AtifTesting" app Version 1002 on your Quest 2 for testing.

Height Task ID (If applicable): T-1796

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules