### PR TITLE
VSP Test Case 54: Exit Poll w/ HMD

### DIFF
--- a/Editor/ExitPollHolderInspector.cs
+++ b/Editor/ExitPollHolderInspector.cs
@@ -227,7 +227,7 @@ namespace Cognitive3D
         private string GetPointerDescription(ExitPollParameters parameters)
         {
             string thingToSpawn = "";
-            if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
+            if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
             {
                 thingToSpawn = "Spawn ExitPollControllerPointer";
             }

--- a/Editor/ExitPollHolderInspector.cs
+++ b/Editor/ExitPollHolderInspector.cs
@@ -120,7 +120,6 @@ namespace Cognitive3D
 
             EditorGUI.indentLevel++;
             p.PointerType = (ExitPoll.PointerType)EditorGUILayout.EnumPopup("Exit Poll Pointer Type", p.PointerType);
-            // p.PointerParent = (ExitPoll.PointerSource)EditorGUILayout.EnumPopup("Exit Poll Pointer Parent", p.PointerParent);
 
             EditorGUILayout.HelpBox(GetPointerDescription(p), MessageType.Info);
             EditorGUI.indentLevel--;

--- a/Editor/ExitPollHolderInspector.cs
+++ b/Editor/ExitPollHolderInspector.cs
@@ -120,37 +120,7 @@ namespace Cognitive3D
 
             EditorGUI.indentLevel++;
             p.PointerType = (ExitPoll.PointerType)EditorGUILayout.EnumPopup("Exit Poll Pointer Type", p.PointerType);
-            if (p.PointerType == ExitPoll.PointerType.CustomPointer)
-            {
-                p.PointerOverride = (GameObject)EditorGUILayout.ObjectField("Pointer Prefab Override", p.PointerOverride, typeof(GameObject), true);
-            }
-            else if (p.PointerType == ExitPoll.PointerType.SceneObject)
-            {
-                p.PointerOverride = (GameObject)EditorGUILayout.ObjectField("Pointer Instance", p.PointerOverride, typeof(GameObject), true);
-
-                if (p.PointerOverride != null && !string.IsNullOrEmpty(AssetDatabase.GetAssetPath(p.PointerOverride)))
-                {
-                    displayPrefabPointerWarning = true;
-                }
-                else if (p.PointerOverride != null && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(p.PointerOverride)))
-                {
-                    displayPrefabPointerWarning = false;
-                }
-
-                if (displayPrefabPointerWarning)
-                {
-                    var rect = GUILayoutUtility.GetLastRect();
-                    rect.width = 20;
-                    GUI.Label(rect, new GUIContent(EditorCore.Alert, "This should reference to a scene asset!\nSelect Custom Pointer if you want to spawn a prefab"));
-                    p.PointerOverride = null;
-                }
-            }
-
-            p.PointerParent = (ExitPoll.PointerSource)EditorGUILayout.EnumPopup("Exit Poll Pointer Parent", p.PointerParent);
-            if (p.PointerParent == ExitPoll.PointerSource.Other)
-            {
-                p.PointerParentOverride = (Transform)EditorGUILayout.ObjectField("Exit Poll Pointer Parent Override", p.PointerParentOverride, typeof(Transform), true);
-            }
+            // p.PointerParent = (ExitPoll.PointerSource)EditorGUILayout.EnumPopup("Exit Poll Pointer Parent", p.PointerParent);
 
             EditorGUILayout.HelpBox(GetPointerDescription(p), MessageType.Info);
             EditorGUI.indentLevel--;
@@ -160,6 +130,21 @@ namespace Cognitive3D
 
             EditorGUI.indentLevel++;
             p.ExitpollSpawnType = (ExitPoll.SpawnType)EditorGUILayout.EnumPopup(p.ExitpollSpawnType);
+            
+            // Setting parent based on pointer type
+            if (p.PointerType == ExitPoll.PointerType.HMDPointer)
+            {
+                p.PointerParent = ExitPoll.PointerSource.HMD;
+            }
+            if (p.PointerType == ExitPoll.PointerType.LeftControllerPointer)
+            {
+                p.PointerParent = ExitPoll.PointerSource.LeftHand;
+            }
+            if (p.PointerType == ExitPoll.PointerType.RightControllerPointer)
+            {
+                p.PointerParent = ExitPoll.PointerSource.RightHand;
+            }
+
             if (p.ExitpollSpawnType == ExitPoll.SpawnType.World)
             {
                 GUILayout.BeginHorizontal();
@@ -242,35 +227,13 @@ namespace Cognitive3D
         private string GetPointerDescription(ExitPollParameters parameters)
         {
             string thingToSpawn = "";
-            if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
+            if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
             {
                 thingToSpawn = "Spawn ExitPollControllerPointer";
             }
             else if(parameters.PointerType == ExitPoll.PointerType.HMDPointer)
             {
                 thingToSpawn = "Spawn ExitPollHMDPointer";
-            }
-            else if (parameters.PointerType == ExitPoll.PointerType.CustomPointer)
-            {
-                if (parameters.PointerOverride != null)
-                {
-                    thingToSpawn = "Spawn " + parameters.PointerOverride.name;
-                }
-                else
-                {
-                    thingToSpawn = "Spawn Nothing";
-                }
-            }
-            else if (parameters.PointerType == ExitPoll.PointerType.SceneObject)
-            {
-                if (parameters.PointerOverride != null)
-                {
-                    thingToSpawn = "Select " + parameters.PointerOverride.name + " from scene";
-                }
-                else
-                {
-                    thingToSpawn = "Select Nothing from scene";
-                }
             }
 
             string howToAttach = "";
@@ -286,30 +249,10 @@ namespace Cognitive3D
             {
                 howToAttach = " and attach to Right Controller";
             }
-            if (parameters.PointerParent == ExitPoll.PointerSource.Other)
-            {
-                if (parameters.PointerParentOverride != null)
-                    howToAttach = " and Attach to " + parameters.PointerParentOverride.name + " in scene";
-                else
-                    howToAttach = " and Attach to Nothing in scene";
-            }
 
             string result = "";
-            if (parameters.PointerType == ExitPoll.PointerType.SceneObject)
-            {
-                if (parameters.PointerParent == ExitPoll.PointerSource.Other && parameters.PointerParentOverride == null)
-                {
-                    result = "\nPointer parenting will not change after ExitPoll closes";
-                }
-                else
-                {
-                    result = "\nPointer will be un-attached after ExitPoll closes";
-                }
-            }
-            else
-            {
-                result = "\nPointer will be destroyed after ExitPoll closes";
-            }
+            result = "\nPointer will be destroyed after ExitPoll closes";
+
             
             return thingToSpawn + howToAttach + result;
         }

--- a/Editor/ExitPollHolderInspector.cs
+++ b/Editor/ExitPollHolderInspector.cs
@@ -227,7 +227,7 @@ namespace Cognitive3D
         private string GetPointerDescription(ExitPollParameters parameters)
         {
             string thingToSpawn = "";
-            if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
+            if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
             {
                 thingToSpawn = "Spawn ExitPollControllerPointer";
             }

--- a/Runtime/ExitPoll/ExitPoll.cs
+++ b/Runtime/ExitPoll/ExitPoll.cs
@@ -182,7 +182,7 @@ namespace Cognitive3D
                 else
                     Debug.LogError("Spawning Exitpoll HMD Pointer, but cannot find prefab \"HMDPointer\" in Resources!");
             }
-            else if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
+            else if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
             {
                 GameObject prefab = Resources.Load<GameObject>("ControllerPointer");
                 if (prefab != null)

--- a/Runtime/ExitPoll/ExitPoll.cs
+++ b/Runtime/ExitPoll/ExitPoll.cs
@@ -59,7 +59,6 @@ namespace Cognitive3D
             HMD,
             RightHand,
             LeftHand,
-            Other
         }
         public enum SpawnType
         {
@@ -69,9 +68,8 @@ namespace Cognitive3D
         public enum PointerType
         {
             HMDPointer,
-            ControllerPointer,
-            CustomPointer,
-            SceneObject
+            RightControllerPointer,
+            LeftControllerPointer,
         }
 
         private static GameObject _exitPollHappySad;
@@ -176,14 +174,7 @@ namespace Cognitive3D
             if (!Cognitive3D_Manager.IsInitialized) { Util.logDebug("Cannot display exitpoll. Session has not begun"); return; }
 
             myparameters = parameters;
-
-            //spawn pointers if override isn't set
-            if (parameters.PointerType == ExitPoll.PointerType.SceneObject)
-            {
-                //spawn nothing. something in the scene is already set   
-                pointerInstance = parameters.PointerOverride;
-            }
-            else if (parameters.PointerType == ExitPoll.PointerType.HMDPointer)
+            if (parameters.PointerType == ExitPoll.PointerType.HMDPointer)
             {
                 GameObject prefab = Resources.Load<GameObject>("HMDPointer");
                 if (prefab != null)
@@ -191,20 +182,13 @@ namespace Cognitive3D
                 else
                     Debug.LogError("Spawning Exitpoll HMD Pointer, but cannot find prefab \"HMDPointer\" in Resources!");
             }
-            else if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
+            else if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
             {
                 GameObject prefab = Resources.Load<GameObject>("ControllerPointer");
                 if (prefab != null)
                     pointerInstance = GameObject.Instantiate(prefab);
                 else
                     Debug.LogError("Spawning Exitpoll Controller Pointer, but cannot find prefab \"ControllerPointer\" in Resources!");
-            }
-            else if (parameters.PointerType == ExitPoll.PointerType.CustomPointer)
-            {
-                if (parameters.PointerOverride != null)
-                    pointerInstance = GameObject.Instantiate(parameters.PointerOverride);
-                else
-                    Debug.LogError("Spawning Exitpoll Pointer, but cannot pointer override prefab is null!");
             }
             
             if (pointerInstance != null)
@@ -232,15 +216,6 @@ namespace Cognitive3D
                     if (GameplayReferences.GetControllerTransform(false, out t))
                     {
                         pointerInstance.transform.SetParent(t);
-                        pointerInstance.transform.localPosition = Vector3.zero;
-                        pointerInstance.transform.localRotation = Quaternion.identity;
-                    }
-                }
-                else if (parameters.PointerParent == ExitPoll.PointerSource.Other)
-                {
-                    if (parameters.PointerParentOverride != null)
-                    {
-                        pointerInstance.transform.SetParent(parameters.PointerParentOverride);
                         pointerInstance.transform.localPosition = Vector3.zero;
                         pointerInstance.transform.localRotation = Quaternion.identity;
                     }
@@ -693,29 +668,7 @@ namespace Cognitive3D
         {
             if (pointerInstance != null)
             {
-                if (myparameters.PointerType != ExitPoll.PointerType.SceneObject)
-                {
-                    GameObject.Destroy(pointerInstance);
-                }
-                else //if pointertype == SceneObject
-                {
-                    if (myparameters.PointerParent != ExitPoll.PointerSource.Other)
-                    {
-                        //unparent
-                        pointerInstance.transform.SetParent(null);
-                    }
-                    else
-                    {
-                        if (myparameters.PointerParentOverride == null)
-                        {
-                            //not parented at startup. don't unparent
-                        }
-                        else
-                        {
-                            pointerInstance.transform.SetParent(null);
-                        }
-                    }
-                }
+                pointerInstance.transform.SetParent(null);
             }
 
             if (myparameters.OnComplete != null && completedSuccessfully == true)

--- a/Runtime/ExitPoll/ExitPoll.cs
+++ b/Runtime/ExitPoll/ExitPoll.cs
@@ -182,7 +182,7 @@ namespace Cognitive3D
                 else
                     Debug.LogError("Spawning Exitpoll HMD Pointer, but cannot find prefab \"HMDPointer\" in Resources!");
             }
-            else if (parameters.PointerType == ExitPoll.PointerType.ControllerPointer)
+            else if (parameters.PointerType == ExitPoll.PointerType.LeftControllerPointer || parameters.PointerType == ExitPoll.PointerType.RightControllerPointer)
             {
                 GameObject prefab = Resources.Load<GameObject>("ControllerPointer");
                 if (prefab != null)

--- a/Runtime/ExitPoll/ExitPoll.cs
+++ b/Runtime/ExitPoll/ExitPoll.cs
@@ -668,7 +668,7 @@ namespace Cognitive3D
         {
             if (pointerInstance != null)
             {
-                pointerInstance.transform.SetParent(null);
+                GameObject.Destroy(pointerInstance);
             }
 
             if (myparameters.OnComplete != null && completedSuccessfully == true)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Unity VSP reported a bug where "ExitPoll cannot be interacted with when Pointer Type is set to HMD". We believe it was because of a bug which allowed users to misconfigure exit poll. This PR fixes that by prevent users from picking pointer parents which make no sense in context of pointer type (or vice versa).

Notion Doc to track Atif's VSP work: https://www.notion.so/cognitive3d/Atif-s-VSP-Stuff-345ec5e492ac4074ae0e2bb2ad6f1d71

Height Task ID (If applicable): T-1915

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules