### PR TITLE
Fix teleport event

### DIFF
--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -17,7 +17,10 @@ namespace Cognitive3D.Components
             base.OnSessionBegin();
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPostSessionEnd += Cognitive3D_Manager_OnPostSessionEnd;
-            lastRootPosition = teleportPlayer.position;
+            if (teleportPlayer != null)
+            {
+                lastRootPosition = teleportPlayer.position;
+            }
         }
 
         void Cognitive3D_Manager_OnUpdate(float deltaTime)

--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -22,18 +22,26 @@ namespace Cognitive3D.Components
 
         void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-            if (Vector3.SqrMagnitude(lastRootPosition - teleportPlayer.position) > 0.1f)
+            if (teleportPlayer != null)
             {
-                Vector3 newPosition = teleportPlayer.position;
-                new CustomEvent("cvr.teleport").SetProperty("distance", Vector3.Distance(newPosition, lastRootPosition)).Send(newPosition);
-                Util.logDebug("teleport");
-                lastRootPosition = teleportPlayer.position;
+                if (Vector3.SqrMagnitude(lastRootPosition - teleportPlayer.position) > 0.1f)
+                {
+                    Vector3 newPosition = teleportPlayer.position;
+                    new CustomEvent("cvr.teleport").SetProperty("distance", Vector3.Distance(newPosition, lastRootPosition)).Send(newPosition);
+                    Util.logDebug("teleport");
+                    lastRootPosition = teleportPlayer.position;
+                }
             }
         }
 
         public override string GetDescription()
         {
             return "Sends a Custom Event when a player's HMD root transform changes positions. If the player moves without an immediate teleport, do not use this component!";
+        }
+
+        public override bool GetError()
+        {
+            return (teleportPlayer == null);
         }
 
         private void Cognitive3D_Manager_OnPostSessionEnd()

--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using System.Collections;
 
 /// <summary>
 /// Sends a Custom Event when a player's HMD root transform changes positions
@@ -10,20 +9,7 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Teleport Event")]
     public class TeleportEvent : AnalyticsComponentBase
     {
-        Transform _root;
-        Transform root
-        {
-            get
-            {
-                if (_root == null)
-                {
-                    if (GameplayReferences.HMD == null) _root = transform;
-                    else { _root = GameplayReferences.HMD.transform; }
-                }
-                return _root;
-            }
-        }
-
+        public Transform teleportPlayer;
         Vector3 lastRootPosition;
 
         protected override void OnSessionBegin()
@@ -31,17 +17,17 @@ namespace Cognitive3D.Components
             base.OnSessionBegin();
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPostSessionEnd += Cognitive3D_Manager_OnPostSessionEnd;
-            lastRootPosition = root.position;
+            lastRootPosition = teleportPlayer.position;
         }
 
         void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-            if (Vector3.SqrMagnitude(lastRootPosition - root.position) > 0.1f)
+            if (Vector3.SqrMagnitude(lastRootPosition - teleportPlayer.position) > 0.1f)
             {
-                Vector3 newPosition = root.position;
+                Vector3 newPosition = teleportPlayer.position;
                 new CustomEvent("cvr.teleport").SetProperty("distance", Vector3.Distance(newPosition, lastRootPosition)).Send(newPosition);
                 Util.logDebug("teleport");
-                lastRootPosition = root.position;
+                lastRootPosition = teleportPlayer.position;
             }
         }
 

--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -16,8 +16,10 @@ namespace Cognitive3D.Components
             get
             {
                 if (_root == null)
+                {
                     if (GameplayReferences.HMD == null) _root = transform;
-                    else { _root = GameplayReferences.HMD.root; }
+                    else { _root = GameplayReferences.HMD.transform; }
+                }
                 return _root;
             }
         }
@@ -37,9 +39,9 @@ namespace Cognitive3D.Components
             if (Vector3.SqrMagnitude(lastRootPosition - root.position) > 0.1f)
             {
                 Vector3 newPosition = root.position;
-
                 new CustomEvent("cvr.teleport").SetProperty("distance", Vector3.Distance(newPosition, lastRootPosition)).Send(newPosition);
                 Util.logDebug("teleport");
+                Debug.Log("Teleport Detected");
 
                 lastRootPosition = root.position;
             }

--- a/Runtime/Components/TeleportEvent.cs
+++ b/Runtime/Components/TeleportEvent.cs
@@ -41,8 +41,6 @@ namespace Cognitive3D.Components
                 Vector3 newPosition = root.position;
                 new CustomEvent("cvr.teleport").SetProperty("distance", Vector3.Distance(newPosition, lastRootPosition)).Send(newPosition);
                 Util.logDebug("teleport");
-                Debug.Log("Teleport Detected");
-
                 lastRootPosition = root.position;
             }
         }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The `Teleport Event` script previously calculated the distance moved by the top-most parent A.K.A `root` of the camera. This assumes that the root will move. However in some cases, the root doesn't move, but an intermediate parent does.
This PR fixes that bug.

Height Task ID (If applicable): https://c3d.height.app/sdk/T-1989

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules