### PR TITLE
Events on VR Guardian Exits

### DIFF
--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -27,10 +27,10 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-            boundaryPointsArray = new Vector3[4];
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
+            boundaryPointsArray = new Vector3[4];
             trackingSpace = GameObject.FindObjectOfType<OVRCameraRig>().trackingSpace;
 #endif
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
@@ -100,6 +100,7 @@ namespace Cognitive3D.Components
 #endif
         }
 
+#if C3D_OCULUS
         private bool HasBoundaryChanged()
         {
             Vector3[] temporaryArray;
@@ -113,6 +114,8 @@ namespace Cognitive3D.Components
             }
             return false;
         }
+#endif
+
         private static bool IsPointInPolygon4(Vector3[] polygon, Vector3 testPoint)
         {
             bool result = false;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -31,7 +31,7 @@ namespace Cognitive3D.Components
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
             boundaryPointsArray = new Vector3[4];
-            trackingSpace = GameObject.FindObjectOfType<OVRCameraRig>().trackingSpace;
+            trackingSpace = TryGetTrackingSpace();
 #endif
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
 
@@ -102,12 +102,12 @@ namespace Cognitive3D.Components
             }
             else 
             {
-                trackingSpace = GameObject.FindObjectOfType<OVRCameraRig>().trackingSpace;
+                trackingSpace = TryGetTrackingSpace();
             }
 #endif
         }
 
-#if C3D_OCULUS
+#if true
         private bool HasBoundaryChanged()
         {
             Vector3[] temporaryArray;
@@ -120,6 +120,16 @@ namespace Cognitive3D.Components
                 }
             }
             return false;
+        }
+
+        private Transform TryGetTrackingSpace()
+        {
+            OVRCameraRig cameraRig = GameObject.FindObjectOfType<OVRCameraRig>();
+            if (cameraRig != null)
+            {
+                return cameraRig.trackingSpace;
+            }
+            return null;
         }
 #endif
 
@@ -141,7 +151,7 @@ namespace Cognitive3D.Components
             return result;
         }
 
-        private void Cognitive3D_Manager_OnPreSessionEnd()
+    private void Cognitive3D_Manager_OnPreSessionEnd()
         {
             Cognitive3D_Manager.OnUpdate -= Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -100,6 +100,10 @@ namespace Cognitive3D.Components
                 }
                 currentTime = 0;
             }
+            else 
+            {
+                trackingSpace = GameObject.FindObjectOfType<OVRCameraRig>().trackingSpace;
+            }
 #endif
         }
 

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -1,7 +1,4 @@
 ﻿using UnityEngine;
-using System.Collections;
-using System;
-using System.Collections.Generic;
 
 #if C3D_STEAMVR || C3D_STEAMVR2
 using Valve.VR;
@@ -19,13 +16,11 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary Event")]
     public class BoundaryEvent : AnalyticsComponentBase
     {
-        public GameObject post;
         private float BoundaryTrackingInterval = 1;
         //counts up the deltatime to determine when the interval ends
         private float currentTime;
 #if C3D_OCULUS
         Vector3[] boundaryPointsArray;
-        Vector3[] transformedBoundaryPoints;
         Transform trackingSpace;
         bool exited = false;
 #endif
@@ -33,7 +28,6 @@ namespace Cognitive3D.Components
         {
             base.OnSessionBegin();
             boundaryPointsArray = new Vector3[4];
-            transformedBoundaryPoints = new Vector3[4];
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
@@ -86,17 +80,11 @@ namespace Cognitive3D.Components
                 if (HasBoundaryChanged())
                 {
                     boundaryPointsArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
-                    for (int i = 0; i < boundaryPointsArray.Length; i++)
-                    {
-                        Vector3 newPoint = trackingSpace.TransformPoint(boundaryPointsArray[i]);
-                        transformedBoundaryPoints[i] = newPoint;
-                        Instantiate(post, newPoint, new Quaternion(0, 0, 0, 0));
-                    }
                 }
             }
 
             // Unity uses y-up coordinate system - the boundary "up" doesn't matters
-            if (!IsPointInPolygon4(transformedBoundaryPoints, GameplayReferences.HMD.position))
+            if (!IsPointInPolygon4(boundaryPointsArray, trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
             {
                 if (!exited)
                 {

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -18,6 +18,13 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary Event")]
     public class BoundaryEvent : AnalyticsComponentBase
     {
+        /// <summary>
+        /// //////////// TEST
+        /// </summary>
+        /// 
+        public GameObject pole;
+
+        //////////////////////////////
 
         [ClampSetting(1f, 5f)]
         [Tooltip("Number of seconds used to average to determine framerate. Lower means more smaller samples and more detail")]
@@ -42,15 +49,10 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-#if XRPF
-            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsSpatialDataAllowed)
-#endif            
-            {
-                Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
-                Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            }
+            Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
+            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
-            Transform trackingSpace = GameObject.Find("TrackingSpace").transform;
+            trackingSpace = GameObject.Find("TrackingSpace").transform;
 #endif
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
 
@@ -95,6 +97,7 @@ namespace Cognitive3D.Components
         void CheckBoundary()
         {
 #if C3D_OCULUS
+            boundaryPointsArray = new Vector3[10]; // usually it is only 4
             boundaryPointsArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
             intervalFrameCount = 0;
             currentTime = 0;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -43,7 +43,7 @@ namespace Cognitive3D.Components
         {
             base.OnSessionBegin();
 #if XRPF
-            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
+            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsSpatialDataAllowed)
 #endif            
             {
                 Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -107,7 +107,7 @@ namespace Cognitive3D.Components
 #endif
         }
 
-#if true
+#if C3D_OCULUS
         private bool HasBoundaryChanged()
         {
             Vector3[] temporaryArray;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -84,19 +84,22 @@ namespace Cognitive3D.Components
             }
 
             // Unity uses y-up coordinate system - the boundary "up" doesn't matters
-            if (!IsPointInPolygon4(boundaryPointsArray, trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
+            if (trackingSpace != null)
             {
-                if (!exited)
+                if (!IsPointInPolygon4(boundaryPointsArray, trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
                 {
-                    new CustomEvent("c3d.user.exited.boundary").Send();
-                    exited = true;
+                    if (!exited)
+                    {
+                        new CustomEvent("c3d.user.exited.boundary").Send();
+                        exited = true;
+                    }
                 }
+                else
+                {
+                    exited = false;
+                }
+                currentTime = 0;
             }
-            else
-            {
-                exited = false;
-            }
-            currentTime = 0;
 #endif
         }
 

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -19,9 +19,6 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary Event")]
     public class BoundaryEvent : AnalyticsComponentBase
     {
-
-        public GameObject pole;
-
         private float BoundaryTrackingInterval = 1;
         //counts up the deltatime to determine when the interval ends
         private float currentTime;
@@ -82,16 +79,22 @@ namespace Cognitive3D.Components
         {
 #if C3D_OCULUS
             boundaryPointsArray = new Vector3[4];
+            Vector3[] transformedBoundaryPoints = new Vector3[4];
             if (OVRManager.boundary != null)
             {
                 if (boundaryPointsArray != OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea))
                 {
                     boundaryPointsArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
+                    for (int i = 0; i < boundaryPointsArray.Length; i++)
+                    {
+                        Vector3 newPoint = trackingSpace.TransformPoint(boundaryPointsArray[i]);
+                        transformedBoundaryPoints[i] = newPoint;
+                    }
                 }
             }
 
             // Unity uses y-up coordinate system - the boundary "up" doesn't matters
-            if (!IsPointInPolygon4(boundaryPointsArray, hmdPosition))
+            if (!IsPointInPolygon4(transformedBoundaryPoints, hmdPosition))
             {
                 if (!exited)
                 {

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -19,18 +19,21 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary Event")]
     public class BoundaryEvent : AnalyticsComponentBase
     {
+        public GameObject post;
         private float BoundaryTrackingInterval = 1;
         //counts up the deltatime to determine when the interval ends
         private float currentTime;
 #if C3D_OCULUS
         Vector3[] boundaryPointsArray;
+        Vector3[] transformedBoundaryPoints;
         Transform trackingSpace;
-        Vector3 hmdPosition;
         bool exited = false;
 #endif
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
+            boundaryPointsArray = new Vector3[4];
+            transformedBoundaryPoints = new Vector3[4];
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
@@ -78,23 +81,22 @@ namespace Cognitive3D.Components
         void CheckBoundary()
         {
 #if C3D_OCULUS
-            boundaryPointsArray = new Vector3[4];
-            Vector3[] transformedBoundaryPoints = new Vector3[4];
             if (OVRManager.boundary != null)
             {
-                if (boundaryPointsArray != OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea))
+                if (HasBoundaryChanged())
                 {
                     boundaryPointsArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
                     for (int i = 0; i < boundaryPointsArray.Length; i++)
                     {
                         Vector3 newPoint = trackingSpace.TransformPoint(boundaryPointsArray[i]);
                         transformedBoundaryPoints[i] = newPoint;
+                        Instantiate(post, newPoint, new Quaternion(0, 0, 0, 0));
                     }
                 }
             }
 
             // Unity uses y-up coordinate system - the boundary "up" doesn't matters
-            if (!IsPointInPolygon4(transformedBoundaryPoints, hmdPosition))
+            if (!IsPointInPolygon4(transformedBoundaryPoints, GameplayReferences.HMD.position))
             {
                 if (!exited)
                 {
@@ -110,6 +112,19 @@ namespace Cognitive3D.Components
 #endif
         }
 
+        private bool HasBoundaryChanged()
+        {
+            Vector3[] temporaryArray;
+            temporaryArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
+            for (int i = 0; i < boundaryPointsArray.Length; i++)
+            {
+                if (Vector3.SqrMagnitude(boundaryPointsArray[i] - temporaryArray[i]) >= 1)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
         private static bool IsPointInPolygon4(Vector3[] polygon, Vector3 testPoint)
         {
             bool result = false;

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -1,5 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
+using System;
+using System.Collections.Generic;
 #if C3D_STEAMVR || C3D_STEAMVR2
 using Valve.VR;
 #endif
@@ -16,12 +18,43 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary Event")]
     public class BoundaryEvent : AnalyticsComponentBase
     {
-#if C3D_STEAMVR2
+
+        [ClampSetting(1f, 5f)]
+        [Tooltip("Number of seconds used to average to determine framerate. Lower means more smaller samples and more detail")]
+        public float BoundaryTrackingInterval = 1;
+        //counts up the deltatime to determine when the interval ends
+        private float currentTime;
+        //the number of frames in the interval
+        private int intervalFrameCount;
+#if C3D_OCULUS
+        Vector3[] boundaryPointsArray;
+        List<float> xCoordinates;
+        List<float> yCoordinates;
+        List<float> zCoordinates;
+        float minX;
+        float maxX;
+        float minY;
+        float maxY;
+        float minZ;
+        float maxZ;
+        Transform trackingSpace;
+#endif        
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
+#if XRPF
+            if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsHardwareDataAllowed)
+#endif            
+            {
+                Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
+                Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+            }
+#if C3D_OCULUS
+            Transform trackingSpace = GameObject.Find("TrackingSpace").transform;
+#endif
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
 
+#if C3D_STEAMVR2
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsHidden).AddListener(OnChaperoneChanged);
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsShown).AddListener(OnChaperoneChanged);
 
@@ -29,10 +62,13 @@ namespace Cognitive3D.Components
             {
                 new CustomEvent("cvr.boundary").Send();
             }
+#endif
         }
 
+#if C3D_STEAMVR2
         private void OnChaperoneChanged(Valve.VR.VREvent_t arg0)
         {
+
             if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
             {
                 new CustomEvent("cvr.boundary").SetProperty("visible", true).Send();
@@ -42,17 +78,80 @@ namespace Cognitive3D.Components
                 new CustomEvent("cvr.boundary").SetProperty("visible", false).Send();
             }
         }
+#endif
+
+        private void Cognitive3D_Manager_OnUpdate(float deltaTime)
+        {
+#if C3D_OCULUS
+            intervalFrameCount++;
+            currentTime += deltaTime;
+            if (currentTime > BoundaryTrackingInterval)
+            {
+                CheckBoundary();
+            }
+#endif
+        }
+
+        void CheckBoundary()
+        {
+#if C3D_OCULUS
+            boundaryPointsArray = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
+            intervalFrameCount = 0;
+            currentTime = 0;
+
+            xCoordinates = new List<float>();
+            yCoordinates = new List<float>();
+            zCoordinates = new List<float>();
+
+            foreach (Vector3 point in boundaryPointsArray)
+            {
+                Vector3 transformedPoint = trackingSpace.TransformPoint(point);
+                xCoordinates.Add(transformedPoint.x);
+                yCoordinates.Add(transformedPoint.y);
+                zCoordinates.Add(transformedPoint.z);
+            }
+
+            xCoordinates.Sort();
+            yCoordinates.Sort();
+            zCoordinates.Sort();
+
+            minX = xCoordinates[0];
+            maxX = xCoordinates[xCoordinates.Count - 1];
+            minY = yCoordinates[0];
+            maxY = yCoordinates[yCoordinates.Count - 1];
+            minZ = zCoordinates[0];
+            maxZ = zCoordinates[zCoordinates.Count - 1];
+
+            Vector3 hmdPosition = GameplayReferences.HMD.position;
+
+            if (hmdPosition.x < minX || hmdPosition.x > maxX
+                || hmdPosition.y < minY || hmdPosition.y > maxY
+                || hmdPosition.z < minZ || hmdPosition.z > maxZ
+                )
+            {
+                new CustomEvent("c3d.user.exited.boundary").Send();
+            }
+#endif
+        }
+
+        private void Cognitive3D_Manager_OnPreSessionEnd()
+        {
+            Cognitive3D_Manager.OnUpdate -= Cognitive3D_Manager_OnUpdate;
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+        }
 
         void OnDestroy()
         {
+            Cognitive3D_Manager_OnPreSessionEnd();
+#if C3D_STEAMVR2
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsHidden).RemoveListener(OnChaperoneChanged);
             Valve.VR.SteamVR_Events.System(Valve.VR.EVREventType.VREvent_Compositor_ChaperoneBoundsShown).RemoveListener(OnChaperoneChanged);
-        }
 #endif
+        }
 
         public override string GetDescription()
         {
-#if C3D_STEAMVR2
+#if C3D_STEAMVR2 || C3D_OCULUS
             return "Sends an event when Boundary becomes visible and becomes hidden";
 #else
             return "Current platform does not support this component";
@@ -61,12 +160,11 @@ namespace Cognitive3D.Components
 
         public override bool GetWarning()
         {
-#if C3D_STEAMVR2
+#if C3D_STEAMVR2 || C3D_OCULUS
             return false;
 #else
             return true;
 #endif
         }
-
     }
 }

--- a/Runtime/Components/BoundaryEvent.cs
+++ b/Runtime/Components/BoundaryEvent.cs
@@ -39,7 +39,7 @@ namespace Cognitive3D.Components
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
 #if C3D_OCULUS
-            trackingSpace = GameObject.Find("TrackingSpace").transform;
+            trackingSpace = GameObject.FindObjectOfType<OVRCameraRig>().trackingSpace;
 #endif
             //Cognitive3D_Manager.PoseEvent += Cognitive3D_Manager_PoseEventHandler;
 
@@ -132,10 +132,17 @@ namespace Cognitive3D.Components
 
             xCoordinates.Sort();
             zCoordinates.Sort();
-            minX = xCoordinates[0];
-            maxX = xCoordinates[xCoordinates.Count - 1];
-            minZ = zCoordinates[0];
-            maxZ = zCoordinates[zCoordinates.Count - 1];
+
+            if (xCoordinates.Count > 0)
+            {
+                minX = xCoordinates[0];
+                maxX = xCoordinates[xCoordinates.Count - 1];
+            }
+            if (zCoordinates.Count > 0)
+            {
+                minZ = zCoordinates[0];
+                maxZ = zCoordinates[zCoordinates.Count - 1];
+            }
             hmdPosition = GameplayReferences.HMD.position;
         }
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Height Task ID (If applicable): https://c3d.height.app/current-sprint/T-1977

We are now able to get events when user exits VR guardian. NOTE: Currently only works on Oculus.
To test, please run sessions using the AtifTesting app, Version 1049.

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules