### PR TITLE
Improvements to Scene Load/Unload

### DIFF
--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -368,7 +368,6 @@ namespace Cognitive3D
 
             if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
             {
-                Debug.Log("I SHOULDNT BE HERE");
                 replacingSceneId = true;
             }
             if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single)
@@ -389,22 +388,18 @@ namespace Cognitive3D
 
         private void SceneManager_SceneUnloaded(UnityEngine.SceneManagement.Scene scene)
         {
-            SetTrackingScene("", true); 
-            var loadingScene = Cognitive3D_Preferences.FindScene(scene.name);
+            var unloadingScene = Cognitive3D_Preferences.FindScene(scene.name);
             string unloadingSceneID = "";
-            if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
+            if (unloadingScene != null && !string.IsNullOrEmpty(unloadingScene.SceneId))
             {
-                unloadingSceneID = loadingScene.SceneId;
+                unloadingSceneID = unloadingScene.SceneId;
             }
             if (unloadingSceneID != "")
             {
                 int index = sceneList.IndexOf(scene);
                 sceneList.RemoveAt(index);
-                if (index == 0)
-                {
-                    UnityEngine.SceneManagement.Scene currentScene = sceneList[0];
-                    SetTrackingScene(currentScene.name, true);
-                }
+                UnityEngine.SceneManagement.Scene currentScene = sceneList[index - 1];
+                SetTrackingScene(currentScene.name, true);
             }
         }
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -60,7 +60,7 @@ namespace Cognitive3D
         [Tooltip("Send HMD Battery Level on the Start and End of the application")]
         public bool SendBatteryLevelOnStartAndEnd;
 
-        private List<UnityEngine.SceneManagement.Scene> sceneList = new List<UnityEngine.SceneManagement.Scene>();
+        private readonly List<Scene> sceneList = new List<Scene>();
 
         /// <summary>
         /// sets instance of Cognitive3D_Manager
@@ -397,7 +397,6 @@ namespace Cognitive3D
         // TODO: CLARIFY 
         private void SceneManager_SceneUnloaded(Scene scene)
         {
-            Scene currentScene;
             if (DoesSceneHaveID(scene))
             {
                 int index = sceneList.IndexOf(scene);

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -59,7 +59,7 @@ namespace Cognitive3D
         [Tooltip("Send HMD Battery Level on the Start and End of the application")]
         public bool SendBatteryLevelOnStartAndEnd;
 
-        private List<string> sceneIDList = new List<string>();
+        private List<UnityEngine.SceneManagement.Scene> sceneList = new List<UnityEngine.SceneManagement.Scene>();
 
         /// <summary>
         /// sets instance of Cognitive3D_Manager
@@ -376,14 +376,14 @@ namespace Cognitive3D
             }
             if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single)
             {
-                sceneIDList.Clear();
+                sceneList.Clear();
                 //DynamicObject.ClearObjectIds();
             }
             if (replacingSceneId)
             {
                 //send all immediately. anything on threads will be out of date when looking for what the current tracking scene is
                 FlushData();
-                sceneIDList.Insert(0, loadingScene.SceneId);
+                sceneList.Insert(0, scene);
                 SetTrackingScene(scene.name, true);
             }
             else
@@ -398,13 +398,20 @@ namespace Cognitive3D
         {
             SetTrackingScene("", true); 
             var loadingScene = Cognitive3D_Preferences.FindScene(scene.name);
-            if (!string.IsNullOrEmpty(loadingScene.SceneId))
+            string unloadingSceneID = "";
+            if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
             {
-
+                unloadingSceneID = loadingScene.SceneId;
             }
-            else
+            if (unloadingSceneID != "")
             {
-
+                int index = sceneList.IndexOf(scene);
+                sceneList.RemoveAt(index);
+                if (index == 0)
+                {
+                    UnityEngine.SceneManagement.Scene currentScene = sceneList[0];
+                    SetTrackingScene(currentScene.name, true);
+                }
             }
         }
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -407,8 +407,16 @@ namespace Cognitive3D
 
         private void SceneManager_SceneUnloaded(UnityEngine.SceneManagement.Scene scene)
         {
-            //TODO for unload scene async, may need to change tracking scene id
-            //a situation where a scene without an ID is loaded additively, then a scene with an id is unloaded, the sceneid will persist
+            SetTrackingScene("", true); 
+            var loadingScene = Cognitive3D_Preferences.FindScene(scene.name);
+            if (!string.IsNullOrEmpty(loadingScene.SceneId))
+            {
+
+            }
+            else
+            {
+
+            }
         }
 
 #region Updates and Loops

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -394,7 +394,6 @@ namespace Cognitive3D
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);
         }
 
-        // TODO: CLARIFY 
         private void SceneManager_SceneUnloaded(Scene scene)
         {
             if (DoesSceneHaveID(scene))
@@ -430,9 +429,9 @@ namespace Cognitive3D
             string unloadingSceneID = "";
             if (unloadingScene != null && !string.IsNullOrEmpty(unloadingScene.SceneId))
             {
-                unloadingSceneID = unloadingScene.SceneId;
+                return true;
             }
-            return (unloadingSceneID != "");
+            return false;
         }
 
 #region Updates and Loops

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -370,10 +370,6 @@ namespace Cognitive3D
             {
                 replacingSceneId = true;
             }
-            if (mode == UnityEngine.SceneManagement.LoadSceneMode.Additive)
-            {
-
-            }
             if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single)
             {
                 sceneList.Clear();

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -426,7 +426,6 @@ namespace Cognitive3D
         private bool DoesSceneHaveID(Scene scene)
         {
             var unloadingScene = Cognitive3D_Preferences.FindScene(scene.name);
-            string unloadingSceneID = "";
             if (unloadingScene != null && !string.IsNullOrEmpty(unloadingScene.SceneId))
             {
                 return true;

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -368,6 +368,7 @@ namespace Cognitive3D
 
             if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
             {
+                Debug.Log("I SHOULDNT BE HERE");
                 replacingSceneId = true;
             }
             if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single)
@@ -381,10 +382,6 @@ namespace Cognitive3D
                 FlushData();
                 sceneList.Insert(0, scene);
                 SetTrackingScene(scene.name, true);
-            }
-            else
-            {
-                SetTrackingScene("", true);
             }
 
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -387,6 +387,10 @@ namespace Cognitive3D
                 sceneList.Insert(0, scene);
                 SetTrackingScene(scene.name, true);
             }
+            else
+            {
+                SetTrackingScene("", true);
+            }
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);
         }
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -27,7 +27,7 @@ namespace Cognitive3D
     public class Cognitive3D_Manager : MonoBehaviour
     {
         public const string SDK_VERSION = "1.0.8";
-
+    
         private static Cognitive3D_Manager instance;
         public static Cognitive3D_Manager Instance
         {
@@ -58,6 +58,8 @@ namespace Cognitive3D
 
         [Tooltip("Send HMD Battery Level on the Start and End of the application")]
         public bool SendBatteryLevelOnStartAndEnd;
+
+        private List<string> sceneIDList = new List<string>();
 
         /// <summary>
         /// sets instance of Cognitive3D_Manager
@@ -362,44 +364,31 @@ namespace Cognitive3D
         {
             var loadingScene = Cognitive3D_Preferences.FindScene(scene.name);
             bool replacingSceneId = false;
+            //if scene loaded has new scene id
 
-            if (mode == UnityEngine.SceneManagement.LoadSceneMode.Additive)
+            if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
             {
-                //if scene loaded has new scene id
-                if (loadingScene != null && !string.IsNullOrEmpty(loadingScene.SceneId))
-                {
-                    replacingSceneId = true;
-                }
-            }
-            if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single || replacingSceneId)
-            {
-                //DynamicObject.ClearObjectIds();
                 replacingSceneId = true;
             }
-            
+            if (mode == UnityEngine.SceneManagement.LoadSceneMode.Additive)
+            {
+
+            }
+            if (mode == UnityEngine.SceneManagement.LoadSceneMode.Single)
+            {
+                sceneIDList.Clear();
+                //DynamicObject.ClearObjectIds();
+            }
             if (replacingSceneId)
             {
                 //send all immediately. anything on threads will be out of date when looking for what the current tracking scene is
                 FlushData();
+                sceneIDList.Insert(0, loadingScene.SceneId);
+                SetTrackingScene(scene.name, true);
             }
-
-            if (replacingSceneId)
+            else
             {
-                if (loadingScene != null)
-                {
-                    if (!string.IsNullOrEmpty(loadingScene.SceneId))
-                    {
-                        SetTrackingScene(scene.name,true);
-                    }
-                    else
-                    {
-                        SetTrackingScene("", true);
-                    }
-                }
-                else
-                {
-                    SetTrackingScene("", true);
-                }
+                SetTrackingScene("", true);
             }
 
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);


### PR DESCRIPTION
# Description

Unloading additive scenes was causing problems with tracking ID. As part of this task, we improved the overall implementation of scene management for both additive and single, encompassing scenes with and without ID. 

This improvement will allow us to tackle and handle various scenarios w.r.t scene loading/unloading.

Notes on notion: https://www.notion.so/cognitive3d/Unity-Scene-Load-8a9f21d53fa94964bde44540f073ac8d?pvs=4

Height Task ID (If applicable) :https://c3d.height.app/current-sprint/T-578

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules