### PR TITLE
[FIX] Focus restored on Dynamic Object Window after upload complete

### DIFF
--- a/Editor/DynamicObjectsWindow.cs
+++ b/Editor/DynamicObjectsWindow.cs
@@ -1241,7 +1241,12 @@ namespace Cognitive3D
                             }
                         }
                         AddOrReplaceDynamic(manifest, manifestList);
-                        UploadManifest(manifest, null);
+                        System.Action refreshWindowOnManifest = delegate
+                        {
+                            GetDashboardManifest();
+                        };
+
+                        UploadManifest(manifest, refreshWindowOnManifest);
                         this.Focus();
                     }
                 });

--- a/Editor/DynamicObjectsWindow.cs
+++ b/Editor/DynamicObjectsWindow.cs
@@ -1208,7 +1208,7 @@ namespace Cognitive3D
                         uploadList.Add(dyn.gameObject);
                     }
                 }
-
+                this.Focus();
                 //upload meshes and ids
                 EditorCore.RefreshSceneVersion(delegate
                 {
@@ -1242,6 +1242,7 @@ namespace Cognitive3D
                         }
                         AddOrReplaceDynamic(manifest, manifestList);
                         UploadManifest(manifest, null);
+                        this.Focus();
                     }
                 });
             });


### PR DESCRIPTION
# Description

The Dynamic Object Window was losing focus because of the confirmation and upload progress modals. That didn't update the upload status and led to confusion. The fix makes the window gain back focus and as a result, the upload status updates. 

To test, please checkout this branch and try creating and uploading a few dynamic objects. Works on my machine.

Height Task ID (If applicable): https://c3d.height.app/T-1980

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules