### PR TITLE
fixed fixation direction math for picoxr

### DIFF
--- a/Runtime/Scripts/FixationRecorder.cs
+++ b/Runtime/Scripts/FixationRecorder.cs
@@ -88,29 +88,11 @@ namespace Cognitive3D
                 return false;
             }
 
-            UnityEngine.XR.InputDevice device;
-            device = UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head);
-            Vector3 headPos;
-            if (!device.TryGetFeatureValue(UnityEngine.XR.CommonUsages.devicePosition, out headPos))
-            {
-                Debug.Log("Cognitive3D::FixationRecorder CombineWorldGazeRay FAILED HEAD POSITION");
-                return false;
-            }
-            Quaternion headRot = Quaternion.identity;
-            if (!device.TryGetFeatureValue(UnityEngine.XR.CommonUsages.deviceRotation, out headRot))
-            {
-                Debug.Log("Cognitive3D::FixationRecorder CombineWorldGazeRay FAILED HEAD ROTATION");
-                return false;
-            }
-
             Vector3 direction;
             if (Unity.XR.PXR.PXR_EyeTracking.GetCombineEyeGazeVector(out direction) && direction.sqrMagnitude > 0.1f)
             {
-                Matrix4x4 matrix = Matrix4x4.identity;
-                matrix = Matrix4x4.TRS(Vector3.zero, headRot, Vector3.one);
-                direction = matrix.MultiplyPoint3x4(direction);
-                ray.origin = headPos;
-                ray.direction = direction;
+                ray.origin = Cognitive3D.GameplayReferences.HMD.position;
+                ray.direction = Cognitive3D.GameplayReferences.HMD.rotation * direction;
                 return true;
             }
             return false;

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -99,38 +99,16 @@ namespace Cognitive3D
 
         static Vector3 GetLookDirection()
         {
-            var ray = new Ray();
-
             if (!Unity.XR.PXR.PXR_Manager.Instance.eyeTracking)
             {
                 //Debug.Log("Cognitive3D::GazeHelper GetLookDirection FAILED MANAGER NO EYE TRACKING");
                 return lastDirection;
             }
 
-            UnityEngine.XR.InputDevice device;
-            device = UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head);
-            Vector3 headPos;
-            if (!device.TryGetFeatureValue(UnityEngine.XR.CommonUsages.devicePosition, out headPos))
-            {
-                Debug.Log("Cognitive3D::GazeHelper GetLookDirection FAILED HEAD POSITION");
-                return lastDirection;
-            }
-            Quaternion headRot = Quaternion.identity;
-            if (!device.TryGetFeatureValue(UnityEngine.XR.CommonUsages.deviceRotation, out headRot))
-            {
-                Debug.Log("Cognitive3D::GazeHelper GetLookDirection FAILED HEAD ROTATION");
-                return lastDirection;
-            }
-
             Vector3 direction;
             if (Unity.XR.PXR.PXR_EyeTracking.GetCombineEyeGazeVector(out direction) && direction.sqrMagnitude > 0.1f)
             {
-                Matrix4x4 matrix = Matrix4x4.identity;
-                matrix = Matrix4x4.TRS(Vector3.zero, headRot, Vector3.one);
-                direction = matrix.MultiplyPoint3x4(direction);
-                ray.origin = headPos;
-                ray.direction = direction;
-                lastDirection = direction;
+                lastDirection = Cognitive3D.GameplayReferences.HMD.rotation * direction;
             }
             return lastDirection;
         }

--- a/Runtime/Scripts/GazeReticle.cs
+++ b/Runtime/Scripts/GazeReticle.cs
@@ -16,9 +16,7 @@ namespace Cognitive3D
         void Update()
         {
             Ray ray = GazeHelper.GetCurrentWorldGazeRay();
-
-            Vector3 newPosition = transform.position;
-            newPosition = ray.GetPoint(Distance);
+            Vector3 newPosition = ray.GetPoint(Distance);
 
             transform.position = Vector3.Lerp(transform.position, newPosition, Speed);
             transform.LookAt(GameplayReferences.HMD.position);


### PR DESCRIPTION
# Description

Simplified and fixed PicoXR SDK gaze direction calculation. It was using local rotation and position and not converting that into world space before calculating fixation points.

Height Task ID (If applicable): 3018

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules