### PR TITLE
Fixed vimeo link to show the correct video

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -129,7 +129,7 @@ namespace Cognitive3D
             //video link
             if (GUI.Button(new Rect(115, 300, 270, 150), "", "video_centered"))
             {
-                Application.OpenURL("https://vimeo.com/749278322");
+                Application.OpenURL("https://vimeo.com/743513121");
             }
 
             var found = Object.FindObjectOfType<Cognitive3D_Manager>();


### PR DESCRIPTION
# Description

This PR  aims to fix an issue where the wrong video link was displayed in the "Scene Setup" window. The change is necessary for ensuring that users access the correct educational content. The PR doesn't introduce any new dependencies. 

**Note:** The video is a bit out-of-date and covers more than just the scene setup. However, it at least addresses the correct context in which the video link shows up.

I tested out the feature by forking the [repo](https://github.com/Mourud/cvr-sdk-unity), making changes, and using the package manager to download the forked package from Unity and testing out the scene setup. 

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules