### PR TITLE
Fixing incorrect Question X out of Y issue

### DIFF
--- a/Runtime/ExitPoll/ExitPoll.cs
+++ b/Runtime/ExitPoll/ExitPoll.cs
@@ -523,7 +523,7 @@ namespace Cognitive3D
                     Cleanup(false);
                     return;
                 }
-                CurrentExitPollPanel.Initialize(panelProperties[currentPanelIndex], panelCount, this);
+                CurrentExitPollPanel.Initialize(panelProperties[currentPanelIndex], panelCount, this, questionSet.questions.Length);
 
                 if (myparameters.ExitpollSpawnType == ExitPoll.SpawnType.World && myparameters.UseAttachTransform)
                 {

--- a/Runtime/ExitPoll/ExitPollPanel.cs
+++ b/Runtime/ExitPoll/ExitPollPanel.cs
@@ -81,7 +81,7 @@ namespace Cognitive3D
         /// <param name="closeAction">called when the player answers or the question is skipped/timed out</param>
         /// <param name="position">where to instantiate the exitpoll window</param>
         /// <param name="exitpollType">what kind of window to instantiate. microphone will automatically appear last</param>
-        public void Initialize(Dictionary<string,string> properties,int panelId, ExitPollSet questionset)
+        public void Initialize(Dictionary<string,string> properties,int panelId, ExitPollSet questionset, int numQuestionsInSet)
         {
             QuestionSet = questionset;
             PanelId = panelId;
@@ -110,7 +110,7 @@ namespace Cognitive3D
 
             if (QuestionNumber != null)
             {
-                QuestionNumber.text = $"Question {panelId + 1} of {properties.Count}";
+                QuestionNumber.text = $"Question {panelId + 1} of {numQuestionsInSet}";
             }
 
             if (properties["type"] == "MULTIPLE")


### PR DESCRIPTION
# Description

Fixing question progress marker in ExitPollPanel, i.e. Question X out of Y. This was reported by customers and was initially mistaken as an issue pertaining to ExitPoll initialization.

Height Task ID (If applicable): N/A

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules