### PR TITLE
Improvements to Boundary Event

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -192,10 +192,10 @@ namespace Cognitive3D
                 }
             }
 
-            GameObject trackingSpaceObjectInScene = FindAnyObjectByType<RoomTrackingSpace>().gameObject;
-            if (trackingSpaceObjectInScene != null)
+            RoomTrackingSpace trackingSpaceInScene = FindAnyObjectByType<RoomTrackingSpace>();
+            if (trackingSpaceInScene != null)
             {
-                trackingSpace = trackingSpaceObjectInScene;
+                trackingSpace = trackingSpaceInScene.gameObject;
             }
 
             if (leftcontroller != null && rightcontroller != null)
@@ -260,7 +260,7 @@ namespace Cognitive3D
             }
         }
 
-        bool AllControllerSetupComplete;
+        bool AllSetupComplete;
 
         void ControllerUpdate()
         {
@@ -344,10 +344,6 @@ namespace Cognitive3D
                     trackingSpace = EditorGUIUtility.GetObjectPickerObject() as GameObject;
                 }
             }
-            if (trackingSpace != null)
-            {
-                trackingSpace.AddComponent<RoomTrackingSpace>();
-            }
 
             //controllers
 #if C3D_STEAMVR2
@@ -362,16 +358,17 @@ namespace Cognitive3D
             leftControllerIsValid = leftcontroller != null;
             rightControllerIsValid = rightcontroller != null;
 
-            AllControllerSetupComplete = false;
+            AllSetupComplete = false;
             if (rightControllerIsValid && leftControllerIsValid && Camera.main != null && mainCameraObject == Camera.main.gameObject)
             {
                 var rdyn = rightcontroller.GetComponent<DynamicObject>();
                 if (rdyn != null && rdyn.IsController && rdyn.IsRight == true)
                 {
                     var ldyn = leftcontroller.GetComponent<DynamicObject>();
-                    if (ldyn != null && ldyn.IsController && ldyn.IsRight == false)
+                    if (ldyn != null && ldyn.IsController && ldyn.IsRight == false
+                        && (trackingSpace != null && trackingSpace.GetComponent<RoomTrackingSpace>() != null)) // Make sure tracking space isn't null before accessing its component
                     {
-                        AllControllerSetupComplete = true;
+                        AllSetupComplete = true;
                     }
                 }
             }
@@ -476,14 +473,19 @@ namespace Cognitive3D
                 }
             }
 
-            if (GUI.Button(new Rect(160, 400, 200, 30), new GUIContent("Setup Controller GameObjects","Attach Dynamic Object components to the controllers and configures them to record button inputs")))
+            if (GUI.Button(new Rect(160, 400, 200, 30), new GUIContent("Setup GameObjects","Setup the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
             {
                 SetupControllers(leftcontroller, rightcontroller);
+                if (trackingSpace != null)
+                {
+                    trackingSpace.AddComponent<RoomTrackingSpace>();
+                }
+
                 UnityEditor.SceneManagement.EditorSceneManager.MarkAllScenesDirty();
                 Event.current.Use();
             }
 
-            if (AllControllerSetupComplete)
+            if (AllSetupComplete)
             {
                 GUI.Label(new Rect(130, 400, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
@@ -1112,8 +1114,8 @@ namespace Cognitive3D
                     }
 
 #else
-                    appearDisabled = !AllControllerSetupComplete;
-                    if (!AllControllerSetupComplete)
+                    appearDisabled = !AllSetupComplete;
+                    if (!AllSetupComplete)
                     {
                         if (appearDisabled)
                         {

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -164,6 +164,7 @@ namespace Cognitive3D
         GameObject leftcontroller;
         GameObject rightcontroller;
         GameObject mainCameraObject;
+        GameObject trackingSpace;
 
         [System.NonSerialized]
         bool initialPlayerSetup;
@@ -253,6 +254,7 @@ namespace Cognitive3D
         }
 
         bool AllControllerSetupComplete;
+
         void ControllerUpdate()
         {
             PlayerSetupStart();
@@ -263,7 +265,7 @@ namespace Cognitive3D
             int hmdRectHeight = 150;
 
             GUI.Label(new Rect(30, hmdRectHeight, 50, 30), "HMD", "boldlabel");
-            if (GUI.Button(new Rect(130, hmdRectHeight, 310, 30), mainCameraObject != null? mainCameraObject.gameObject.name:"Missing", "button_blueoutline"))
+            if (GUI.Button(new Rect(180, hmdRectHeight, 255, 30), mainCameraObject != null? mainCameraObject.gameObject.name:"Missing", "button_blueoutline"))
             {
                 Selection.activeGameObject = mainCameraObject;
             }
@@ -310,11 +312,41 @@ namespace Cognitive3D
                 }
             }
 
+
+            // tracking space
+            int hmdRectHeight2 = 200;
+
+            GUI.Label(new Rect(30, hmdRectHeight2, 150, 30), "Tracking Space", "boldlabel");
+            if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? "Tracking Space" : "Missing Tracking Space", "button_blueoutline"))
+            {
+                Selection.activeGameObject = trackingSpace;
+            }
+
+            int pickerID_HMD2 = 5689467;
+            if (GUI.Button(new Rect(440, hmdRectHeight2, 30, 30), EditorCore.SearchIconWhite))
+            {
+                GUI.skin = null;
+                EditorGUIUtility.ShowObjectPicker<GameObject>(
+                    trackingSpace, true, "", pickerID_HMD2);
+                GUI.skin = EditorCore.WizardGUISkin;
+            }
+            if (Event.current.commandName == "ObjectSelectorUpdated")
+            {
+                if (EditorGUIUtility.GetObjectPickerControlID() == pickerID_HMD2)
+                {
+                    trackingSpace = EditorGUIUtility.GetObjectPickerObject() as GameObject;
+                }
+            }
+            if (trackingSpace != null)
+            {
+                Cognitive3D_Manager.Instance.TrackingSpace = trackingSpace.transform;
+            }
+
             //controllers
 #if C3D_STEAMVR2
-            GUI.Label(new Rect(30, 200, 440, 440), "The Controllers should have <b>SteamVR Behaviour Pose</b> components", "normallabel");
+            GUI.Label(new Rect(30, 250, 440, 440), "The Controllers should have <b>SteamVR Behaviour Pose</b> components", "normallabel");
 #else
-            GUI.Label(new Rect(30, 200, 440, 440), "The Controllers may have <b>Tracked Pose Driver</b> components", "normallabel");
+            GUI.Label(new Rect(30, 250, 440, 440), "The Controllers may have <b>Tracked Pose Driver</b> components", "normallabel");
 #endif
 
             bool leftControllerIsValid = false;
@@ -336,15 +368,15 @@ namespace Cognitive3D
                     }
                 }
             }
-            int handOffset = 240;
+            int handOffset = 290;
 
             //left hand label
-            GUI.Label(new Rect(30, handOffset + 15, 50, 30), "Left", "boldlabel");
+            GUI.Label(new Rect(30, handOffset + 15, 150, 30), "Left Controller", "boldlabel");
 
             string leftname = "Missing";
             if (leftcontroller != null)
                 leftname = leftcontroller.gameObject.name;
-            if (GUI.Button(new Rect(130, handOffset + 15, 310, 30), leftname, "button_blueoutline"))
+            if (GUI.Button(new Rect(180, handOffset + 15, 255, 30), leftname, "button_blueoutline"))
             {
                 Selection.activeGameObject = leftcontroller;
             }
@@ -371,13 +403,13 @@ namespace Cognitive3D
             }
 
             //right hand label
-            GUI.Label(new Rect(30, handOffset + 50, 50, 30), "Right", "boldlabel");
+            GUI.Label(new Rect(30, handOffset + 50, 150, 30), "Right Controller", "boldlabel");
 
             string rightname = "Missing";
             if (rightcontroller != null)
                 rightname = rightcontroller.gameObject.name;
 
-            if (GUI.Button(new Rect(130, handOffset + 50, 310, 30), rightname, "button_blueoutline"))
+            if (GUI.Button(new Rect(180, handOffset + 50, 255, 30), rightname, "button_blueoutline"))
             {
                 Selection.activeGameObject = rightcontroller;
             }
@@ -404,7 +436,7 @@ namespace Cognitive3D
             }
 
             //drag and drop
-            if (new Rect(30, handOffset + 50, 440, 30).Contains(Event.current.mousePosition)) //right hand
+            if (new Rect(180, handOffset + 50, 440, 30).Contains(Event.current.mousePosition)) //right hand
             {
                 DragAndDrop.visualMode = DragAndDropVisualMode.Link;
                 if (Event.current.type == EventType.DragPerform)
@@ -412,7 +444,7 @@ namespace Cognitive3D
                     rightcontroller = (GameObject)DragAndDrop.objectReferences[0];
                 }
             }
-            else if (new Rect(30, handOffset + 15, 440, 30).Contains(Event.current.mousePosition)) //left hand
+            else if (new Rect(180, handOffset + 15, 440, 30).Contains(Event.current.mousePosition)) //left hand
             {
                 DragAndDrop.visualMode = DragAndDropVisualMode.Link;
                 if (Event.current.type == EventType.DragPerform)
@@ -420,7 +452,7 @@ namespace Cognitive3D
                     leftcontroller = (GameObject)DragAndDrop.objectReferences[0];
                 }
             }
-            else if (new Rect(30, hmdRectHeight, 440, 30).Contains(Event.current.mousePosition)) //hmd
+            else if (new Rect(180, hmdRectHeight, 440, 30).Contains(Event.current.mousePosition)) //hmd
             {
                 DragAndDrop.visualMode = DragAndDropVisualMode.Link;
                 if (Event.current.type == EventType.DragPerform)
@@ -428,8 +460,16 @@ namespace Cognitive3D
                     mainCameraObject = (GameObject)DragAndDrop.objectReferences[0];
                 }
             }
+            else if (new Rect(180, hmdRectHeight2, 440, 30).Contains(Event.current.mousePosition)) // trackingSpace
+            {
+                DragAndDrop.visualMode = DragAndDropVisualMode.Link;
+                if (Event.current.type == EventType.DragPerform)
+                {
+                    trackingSpace = (GameObject)DragAndDrop.objectReferences[0];
+                }
+            }
 
-            if (GUI.Button(new Rect(150, 340, 200, 30), new GUIContent("Setup Controller GameObjects","Attach Dynamic Object components to the controllers and configures them to record button inputs")))
+            if (GUI.Button(new Rect(160, 400, 200, 30), new GUIContent("Setup Controller GameObjects","Attach Dynamic Object components to the controllers and configures them to record button inputs")))
             {
                 SetupControllers(leftcontroller, rightcontroller);
                 UnityEditor.SceneManagement.EditorSceneManager.MarkAllScenesDirty();
@@ -438,17 +478,17 @@ namespace Cognitive3D
 
             if (AllControllerSetupComplete)
             {
-                GUI.Label(new Rect(120, 340, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 400, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(118, 340, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 400, 32, 32), EditorCore.Alert, "image_centered");
             }
 #if C3D_STEAMVR2
 
             //generate default input file if it doesn't already exist
             bool hasInputActionFile = SteamVR_Input.DoesActionsFileExist();
-            if (GUI.Button(new Rect(150, 380, 200, 30), "Append Input Bindings"))
+            if (GUI.Button(new Rect(160, 450, 200, 30), "Append Input Bindings"))
             {
                 if (SteamVR_Input.actionFile == null)
                 {
@@ -472,11 +512,11 @@ namespace Cognitive3D
             }
             if (DoesC3DInputActionSetExist())
             {
-                GUI.Label(new Rect(120, 380, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 450, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(118, 380, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 380, 32, 32), EditorCore.Alert, "image_centered");
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -179,6 +179,7 @@ namespace Cognitive3D
             {
                 mainCameraObject = camera.gameObject;
             }
+
             foreach(var dyn in FindObjectsOfType<DynamicObject>())
             {
                 if (dyn.IsController && dyn.IsRight)
@@ -189,6 +190,11 @@ namespace Cognitive3D
                 {
                     leftcontroller = dyn.gameObject;
                 }
+            }
+
+            if (Cognitive3D_Manager.Instance.TrackingSpace != null)
+            {
+                trackingSpace = Cognitive3D_Manager.Instance.TrackingSpace.gameObject;
             }
 
             if (leftcontroller != null && rightcontroller != null)

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -192,9 +192,10 @@ namespace Cognitive3D
                 }
             }
 
-            if (Cognitive3D_Manager.Instance.TrackingSpace != null)
+            GameObject trackingSpaceObjectInScene = FindAnyObjectByType<RoomTrackingSpace>().gameObject;
+            if (trackingSpaceObjectInScene != null)
             {
-                trackingSpace = Cognitive3D_Manager.Instance.TrackingSpace.gameObject;
+                trackingSpace = trackingSpaceObjectInScene;
             }
 
             if (leftcontroller != null && rightcontroller != null)
@@ -345,7 +346,7 @@ namespace Cognitive3D
             }
             if (trackingSpace != null)
             {
-                Cognitive3D_Manager.Instance.TrackingSpace = trackingSpace.transform;
+                trackingSpace.AddComponent<RoomTrackingSpace>();
             }
 
             //controllers

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -192,7 +192,7 @@ namespace Cognitive3D
                 }
             }
 
-            RoomTrackingSpace trackingSpaceInScene = FindAnyObjectByType<RoomTrackingSpace>();
+            RoomTrackingSpace trackingSpaceInScene = FindObjectOfType<RoomTrackingSpace>();
             if (trackingSpaceInScene != null)
             {
                 trackingSpace = trackingSpaceInScene.gameObject;

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -1093,8 +1093,8 @@ namespace Cognitive3D
                     break;
                 case Page.PlayerSetup:
 #if C3D_STEAMVR2
-                    appearDisabled = !AllControllerSetupComplete;
-                    if (!AllControllerSetupComplete)
+                    appearDisabled = !AllSetupComplete;
+                    if (!AllSetupComplete)
                     {
                         if (appearDisabled)
                         {

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -324,7 +324,7 @@ namespace Cognitive3D
             int hmdRectHeight2 = 185;
 
             GUI.Label(new Rect(30, hmdRectHeight2, 150, 30), "Tracking Space", "boldlabel");
-            if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? "Tracking Space" : "Missing", "button_blueoutline"))
+            if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? trackingSpace.name : "Missing", "button_blueoutline"))
             {
                 Selection.activeGameObject = trackingSpace;
             }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -525,7 +525,7 @@ namespace Cognitive3D
             }
             else
             {
-                GUI.Label(new Rect(128, 380, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 450, 32, 32), EditorCore.Alert, "image_centered");
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -321,10 +321,10 @@ namespace Cognitive3D
 
 
             // tracking space
-            int hmdRectHeight2 = 200;
+            int hmdRectHeight2 = 185;
 
             GUI.Label(new Rect(30, hmdRectHeight2, 150, 30), "Tracking Space", "boldlabel");
-            if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? "Tracking Space" : "Missing Tracking Space", "button_blueoutline"))
+            if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? "Tracking Space" : "Missing", "button_blueoutline"))
             {
                 Selection.activeGameObject = trackingSpace;
             }
@@ -343,6 +343,10 @@ namespace Cognitive3D
                 {
                     trackingSpace = EditorGUIUtility.GetObjectPickerObject() as GameObject;
                 }
+            }
+            if (trackingSpace == null)
+            {
+                GUI.Label(new Rect(400, hmdRectHeight2, 30, 30), new GUIContent(EditorCore.Alert, "Tracking Space not set"), "image_centered");
             }
 
             //controllers
@@ -476,7 +480,7 @@ namespace Cognitive3D
             if (GUI.Button(new Rect(160, 400, 200, 30), new GUIContent("Setup GameObjects","Setup the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
             {
                 SetupControllers(leftcontroller, rightcontroller);
-                if (trackingSpace != null)
+                if (trackingSpace != null && trackingSpace.GetComponent<RoomTrackingSpace>() == null)
                 {
                     trackingSpace.AddComponent<RoomTrackingSpace>();
                 }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -26,6 +26,7 @@ namespace Cognitive3D.Components
             boundaryPoints = GetBoundaryPoints();
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
+            GameplayReferences.GetRoomSize(ref lastRoomSize);
             CalculateAndRecordRoomsize(false, false);
         }
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -55,12 +55,17 @@ namespace Cognitive3D.Components
         /// <returns>True if boundary changed, false otherwise</returns>
         private bool HasBoundaryChanged(Vector3[] previousBoundary, Vector3[] currentBoundary)
         {
-            // this is for a very specific case where boundary exit sometimes causes an empty array from GetBoundaryPoints and hence "fake recenter" events
-            // better to have false negative than a false positive
-            if ((previousBoundary.Length > 0) && (currentBoundary.Length == 0)) {  return false; }
-
             if ((previousBoundary == null && currentBoundary != null) || (previousBoundary != null && currentBoundary == null)) { return true; }
             if (previousBoundary == null && currentBoundary == null) { return false; }
+
+
+            // OCULUS SPECIFIC HACK 
+            // Going far beyond boundary sometimes causes a pause
+            // which causes GetBoundaryPoints() to return empty array and hence fires "fake recenter" events
+            // Better to have false negative than a false positive
+            if ((previousBoundary.Length > 0) && (currentBoundary.Length == 0)) { return false; }
+
+
             if (previousBoundary.Length != currentBoundary.Length) { return true; }
 
             for (int i = 0; i < previousBoundary.Length; i++)

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -22,6 +22,77 @@ namespace Cognitive3D.Components
         //counts up the deltatime to determine when the interval ends
         float currentTime;
 
+
+        protected override void OnSessionBegin()
+        {
+            base.OnSessionBegin();
+            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+            Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
+            CalculateAndRecordRoomsize(false);
+        }
+
+        private void Cognitive3D_Manager_OnUpdate(float deltaTime)
+        {
+            currentTime += deltaTime;
+            if (currentTime > BoundaryTrackingInterval)
+            {
+                if (HasBoundaryChanged())
+                {
+                    boundaryPoints = GetBoundaryPoints();
+                    CalculateAndRecordRoomsize(true);
+                }
+                SendEventIfUserExitsBoundary();
+                currentTime = 0;
+            }
+        }
+
+        /// <summary>
+        /// Determines if user changed their boundary
+        /// </summary>
+        /// <returns>True if boundary changed, false otherwise</returns>
+        private bool HasBoundaryChanged()
+        {
+            List<Vector3> temporaryList = GetBoundaryPoints();
+            for (int i = 0; i < boundaryPoints.Count; i++)
+            {
+                if (Vector3.SqrMagnitude(boundaryPoints[i] - temporaryList[i]) >= 1)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Sends a custom event when the user's HMD exits the boundary
+        /// </summary>
+        void SendEventIfUserExitsBoundary()
+        {
+            if (trackingSpace != null)
+            {
+                if (!IsPointInPolygon4(boundaryPoints.ToArray(), trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
+                {
+                    if (!exited)
+                    {
+                        new CustomEvent("c3d.user.exited.boundary").Send();
+                        exited = true;
+                    }
+                }
+                else
+                {
+                    exited = false;
+                }
+            }
+            else
+            {
+                // Tracking space unavailable: Maybe send an event or property?
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the coordinates of the corners of a quadrilateral representing the user defined boundary
+        /// </summary>
+        /// <returns>A List of Vector3 representing the corners of the user defined boundary</returns>
         private List<Vector3> GetBoundaryPoints()
         {
 
@@ -43,129 +114,28 @@ namespace Cognitive3D.Components
         return boundaryPoints;
 
 #else
-        // Using Unity's XRInputSubsystem as fallback
-        List <XRInputSubsystem> subsystems = new List <XRInputSubsystem>();
-        SubsystemManager.GetInstances<XRInputSubsystem>(subsystems);
+            // Using Unity's XRInputSubsystem as fallback
+            List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();
+            SubsystemManager.GetInstances<XRInputSubsystem>(subsystems);
 
-        // Handling case of multiple subsystems to find the first one that "works"
-        foreach (XRInputSubsystem subsystem in subsystems)
-        {
-            if (!subsystem.running)
+            // Handling case of multiple subsystems to find the first one that "works"
+            foreach (XRInputSubsystem subsystem in subsystems)
             {
-                continue;
-            }
-            if (subsystem.TryGetBoundaryPoints(boundaryPoints))
-            {
+                if (!subsystem.running)
+                {
+                    continue;
+                }
+                if (subsystem.TryGetBoundaryPoints(boundaryPoints))
+                {
+                    return boundaryPoints;
+                }
+
+                // Probably will return empty list; need to append with warning or somethings
                 return boundaryPoints;
             }
-        }
-        // Unable to find boundary points - should we send an event?
+            // Unable to find boundary points - should we send an event?
 #endif
-            return boundaryPoints;
         }
-
-        /// <summary>
-        /// Determines if user changed their boundary
-        /// </summary>
-        /// <returns>True if boundary changed, false otherwise</returns>
-        private bool HasBoundaryChanged()
-        {
-            List<Vector3> temporaryList = GetBoundaryPoints();
-            for (int i = 0; i < boundaryPoints.Count; i++)
-            {
-                if (Vector3.SqrMagnitude(boundaryPoints[i] - temporaryList[i]) >= 1)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        #region SteamVR Specific Utils
-
-#if C3D_STEAMVR2
-        /// <summary>
-        /// Converts Valve's HmdQuad_t array to a List of Vector3. 
-        /// Used for the very specific use-case of boundary points.
-        /// </summary>
-        /// <param name="steamArray"> An array of HmdQuad_t structs</param>
-        /// <returns> A list of 4 Vector3 elements </returns>
-        private List<Vector3> GetValveArrayAsList(Valve.VR.HmdQuad_t[] steamArray)
-        {
-            List<Vector3> steamList = new List<Vector3>();
-            Valve.VR.HmdQuad_t currentQuad = steamArray[0];
-            steamList.Add(SteamQuadtToVector(currentQuad.vCorners0));
-            steamList.Add(SteamQuadtToVector(currentQuad.vCorners1));
-            steamList.Add(SteamQuadtToVector(currentQuad.vCorners2));
-            steamList.Add(SteamQuadtToVector(currentQuad.vCorners3));
-            return steamList;
-        }
-
-        /// <summary>
-        /// Converts a Valve.VR HmdVector3_t struct to a Unity Vector3
-        /// </summary>
-        /// <param name="point">A struct of type Valve.VR.HmdVector3_t</param>
-        /// <returns>A Vector3 representation of the Valve.VR point</returns>
-        private Vector3 SteamQuadtToVector(Valve.VR.HmdVector3_t point)
-        {
-            Vector3 myPoint = new Vector3(point.v0, point.v1, point.v2);
-            return myPoint;
-        }
-#endif
-
-        #endregion
-
-
-        protected override void OnSessionBegin()
-        {
-            base.OnSessionBegin();
-            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
-            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            CalculateAndRecordRoomsize(false);
-        }
-
-        private void Cognitive3D_Manager_OnUpdate(float deltaTime)
-        {
-            currentTime += deltaTime;
-            if (currentTime > BoundaryTrackingInterval)
-            {
-                CheckBoundary();
-            }
-        }
-
-        void CheckBoundary()
-        {
-            if (OVRManager.boundary != null)
-            {
-                if (HasBoundaryChanged())
-                {
-                    boundaryPoints = GetBoundaryPoints();
-                    CalculateAndRecordRoomsize(true);
-                }
-            }
-            if (trackingSpace != null)
-            {
-                if (!IsPointInPolygon4(boundaryPoints.ToArray(), trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
-                {
-                    if (!exited)
-                    {
-                        new CustomEvent("c3d.user.exited.boundary").Send();
-                        exited = true;
-                    }
-                }
-                else
-                {
-                    exited = false;
-                }
-                currentTime = 0;
-            }
-            else
-            {
-                // Tracking space unavailable: Maybe send an event or property?
-            }
-        }
-
 
         /// <summary>
         /// Determines if a point is within a polygon
@@ -191,6 +161,11 @@ namespace Cognitive3D.Components
             return result;
         }
 
+        /// <summary>
+        /// Called at session beginning and when boundary changes.
+        /// Sets the new roomsize as a session property and if the bool param is true, records the boundary change as a custom event
+        /// </summary>
+        /// <param name="recordRoomSizeChangeAsEvent">Flag to enable recording a custom event</param>
         private void CalculateAndRecordRoomsize(bool recordRoomSizeChangeAsEvent)
         {
             Vector3 roomsize = new Vector3();
@@ -219,6 +194,40 @@ namespace Cognitive3D.Components
                 Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", "Invalid");
             }
         }
+
+#region SteamVR Specific Utils
+
+    #if C3D_STEAMVR2
+            /// <summary>
+            /// Converts Valve's HmdQuad_t array to a List of Vector3. 
+            /// Used for the very specific use-case of boundary points.
+            /// </summary>
+            /// <param name="steamArray"> An array of HmdQuad_t structs</param>
+            /// <returns> A list of 4 Vector3 elements </returns>
+            private List<Vector3> GetValveArrayAsList(Valve.VR.HmdQuad_t[] steamArray)
+            {
+                List<Vector3> steamList = new List<Vector3>();
+                Valve.VR.HmdQuad_t currentQuad = steamArray[0];
+                steamList.Add(SteamQuadtToVector(currentQuad.vCorners0));
+                steamList.Add(SteamQuadtToVector(currentQuad.vCorners1));
+                steamList.Add(SteamQuadtToVector(currentQuad.vCorners2));
+                steamList.Add(SteamQuadtToVector(currentQuad.vCorners3));
+                return steamList;
+            }
+
+            /// <summary>
+            /// Converts a Valve.VR HmdVector3_t struct to a Unity Vector3
+            /// </summary>
+            /// <param name="point">A struct of type Valve.VR.HmdVector3_t</param>
+            /// <returns>A Vector3 representation of the Valve.VR point</returns>
+            private Vector3 SteamQuadtToVector(Valve.VR.HmdVector3_t point)
+            {
+                Vector3 myPoint = new Vector3(point.v0, point.v1, point.v2);
+                return myPoint;
+            }
+    #endif
+
+#endregion
 
         private void Cognitive3D_Manager_OnPreSessionEnd()
         {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using OVR.OpenVR;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.XR;
@@ -71,9 +72,10 @@ namespace Cognitive3D.Components
         /// </summary>
         void SendEventIfUserExitsBoundary()
         {
-            if (Cognitive3D_Manager.Instance.trackingSpace != null)
+            Transform trackingSpace = null;
+            if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(ref trackingSpace))
             {
-                if (!IsPointInPolygon4(boundaryPoints.ToArray(), Cognitive3D_Manager.Instance.trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
+                if (!IsPointInPolygon4(boundaryPoints.ToArray(), trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
                 {
                     if (!exited)
                     {
@@ -88,7 +90,7 @@ namespace Cognitive3D.Components
             }
             else
             {
-                Debug.LogWarning("Tracking Space not available");
+                Debug.Log("Tracking Space not found");
             }
         }
 
@@ -113,10 +115,7 @@ namespace Cognitive3D.Components
             Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
             setup.GetWorkingCollisionBoundsInfo(out steamVRBoundaryPoints);
             retrievedPoints = GetValveArrayAsList(steamVRBoundaryPoints);
-            //  Debug.Log(steamVRBoundaryPoints.Length);
-            // LogTheArray(steamVRBoundaryPoints);
             return retrievedPoints;
-
     #else
                 // Using Unity's XRInputSubsystem as fallback
                 List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -66,9 +66,9 @@ namespace Cognitive3D.Components
         /// </summary>
         void SendEventIfUserExitsBoundary()
         {
-            if (Cognitive3D_Manager.Instance.TrackingSpace != null)
+            if (Cognitive3D_Manager.Instance.trackingSpace != null)
             {
-                if (!IsPointInPolygon4(boundaryPoints.ToArray(), Cognitive3D_Manager.Instance.TrackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
+                if (!IsPointInPolygon4(boundaryPoints.ToArray(), Cognitive3D_Manager.Instance.trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
                 {
                     if (!exited)
                     {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,6 +1,4 @@
-﻿using OVR.OpenVR;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 
@@ -106,7 +104,13 @@ namespace Cognitive3D.Components
             {
                 return null;
             }
-            retrievedPoints = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea).ToList();
+            
+            // GetGeometry returns an array but we are using lists
+            // Writing this code ourselves is better than importing a whole library just for one functions
+            foreach (var point in OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea))
+            {
+                retrievedPoints.Add(point);
+            }
             return retrievedPoints;
 
     #elif C3D_STEAMVR2
@@ -200,13 +204,10 @@ namespace Cognitive3D.Components
                         SensorRecorder.RecordDataPoint("RoomSize", roomsize.x * roomsize.z);
                         if (recordRoomSizeChangeAsEvent)
                         {
+                            // Chain SetProperty() instead of one SetProperties() to avoid creating dictionary and garbage
                             new CustomEvent("c3d.User changed boundary")
-                            .SetProperties(
-                                new Dictionary<string, object>
-                                {
-                                    {  "Previous Room Size" , lastRoomSize.x * lastRoomSize.z },
-                                    {   "New Room Size" , roomsize.x * roomsize.z }
-                                })
+                            .SetProperty("Previous Room Size", lastRoomSize.x * lastRoomSize.z)
+                            .SetProperty("New Room Size", roomsize.x * roomsize.z)
                             .Send();
                         }
                         lastRoomSize = roomsize;

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.XR;
+using TMPro;
 
 /// <summary>
 /// Adds room size from SteamVR chaperone to device info
@@ -22,7 +22,6 @@ namespace Cognitive3D.Components
         //counts up the deltatime to determine when the interval ends
         float currentTime;
 
-
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
@@ -33,6 +32,7 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
+
             currentTime += deltaTime;
             if (currentTime > BoundaryTrackingInterval)
             {
@@ -105,12 +105,13 @@ namespace Cognitive3D.Components
         return boundaryPoints;
 
 #elif C3D_STEAMVR2
-        // Valve.VR/OpenVR Array; we will convert it to list for ease of use. Array of size 1 because we are representing 1 rectangle
-        Valve.VR.HmdQuad_t[] steamVRBoundaryPoints = new Valve.VR.HmdQuad_t[1]; 
-        
+        // Valve.VR/OpenVR Array; we will convert it to list for ease of use
+        Valve.VR.HmdQuad_t[] steamVRBoundaryPoints;
         Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
         setup.GetWorkingCollisionBoundsInfo(out steamVRBoundaryPoints);
         boundaryPoints = GetValveArrayAsList(steamVRBoundaryPoints);
+        //  Debug.Log(steamVRBoundaryPoints.Length);
+        // LogTheArray(steamVRBoundaryPoints);
         return boundaryPoints;
 
 #else
@@ -149,6 +150,7 @@ namespace Cognitive3D.Components
             int j = polygon.Length - 1;
             for (int i = 0; i < polygon.Length; i++)
             {
+                // Only using x and z coordinates because Unity is "y-up" and boundary is infinitely high
                 if (polygon[i].z < testPoint.z && polygon[j].z >= testPoint.z || polygon[j].z < testPoint.z && polygon[i].z >= testPoint.z)
                 {
                     if (polygon[i].x + (testPoint.z - polygon[i].z) / (polygon[j].z - polygon[i].z) * (polygon[j].x - polygon[i].x) < testPoint.x)
@@ -207,14 +209,17 @@ namespace Cognitive3D.Components
             private List<Vector3> GetValveArrayAsList(Valve.VR.HmdQuad_t[] steamArray)
             {
                 List<Vector3> steamList = new List<Vector3>();
-                Valve.VR.HmdQuad_t currentQuad = steamArray[0];
-                steamList.Add(SteamQuadtToVector(currentQuad.vCorners0));
-                steamList.Add(SteamQuadtToVector(currentQuad.vCorners1));
-                steamList.Add(SteamQuadtToVector(currentQuad.vCorners2));
-                steamList.Add(SteamQuadtToVector(currentQuad.vCorners3));
+                for (int i = 0; i < steamArray.Length; i++)
+                {
+                    Valve.VR.HmdQuad_t currentQuad = steamArray[i];
+                    steamList.Add(SteamQuadtToVector(currentQuad.vCorners0));
+                    steamList.Add(SteamQuadtToVector(currentQuad.vCorners1));
+                    steamList.Add(SteamQuadtToVector(currentQuad.vCorners2));
+                    steamList.Add(SteamQuadtToVector(currentQuad.vCorners3));
+                }
                 return steamList;
             }
-
+            
             /// <summary>
             /// Converts a Valve.VR HmdVector3_t struct to a Unity Vector3
             /// </summary>

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -321,7 +321,7 @@ namespace Cognitive3D.Components
 #if C3D_STEAMVR2
             float roomX = 0;
             float roomY = 0;
-            if (Valve.VR.OpenVR.Chaperone == null || !Valve.VR.OpenVR.Chaperone.GetPlayAreaSize(ref roomX, ref roomY))
+            if (Valve.VR.OpenVR.Chaperone != null && Valve.VR.OpenVR.Chaperone.GetPlayAreaSize(ref roomX, ref roomY))
             {
                 roomSize = new Vector3(roomX, 0, roomY);
                 return true;
@@ -420,26 +420,12 @@ namespace Cognitive3D.Components
         /// <returns> A list of 4 Vector3 elements </returns>
         private Vector3[] ConvertSteamVRToUnityBounds(Valve.VR.HmdQuad_t[] steamArray)
         {
-            Vector3[] returnArray = new Vector3[steamArray.Length * 4];
-            for (int i = 0; i < steamArray.Length; i+=4)
+            Vector3[] returnArray = new Vector3[steamArray.Length];
+            for (int i = 0; i < steamArray.Length; i++)
             {
                 returnArray[i] = SteamHMDVector3tToVector(steamArray[i].vCorners0);
-                returnArray[i+1] = SteamHMDVector3tToVector(steamArray[i].vCorners1);
-                returnArray[i+2] = SteamHMDVector3tToVector(steamArray[i].vCorners2);
-                returnArray[i+3] = SteamHMDVector3tToVector(steamArray[i].vCorners3);
             }
             return returnArray;
-
-            //List<Vector3> steamList = new List<Vector3>();
-            //for (int i = 0; i < steamArray.Length; i++)
-            //{
-            //    Valve.VR.HmdQuad_t currentQuad = steamArray[i];
-            //    steamList.Add(SteamHMDVector3tToVector(currentQuad.vCorners0));
-            //    steamList.Add(SteamHMDVector3tToVector(currentQuad.vCorners1));
-            //    steamList.Add(SteamHMDVector3tToVector(currentQuad.vCorners2));
-            //    steamList.Add(SteamHMDVector3tToVector(currentQuad.vCorners3));
-            //}
-            //return steamList;
         }
             
         /// <summary>

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -195,11 +195,6 @@ namespace Cognitive3D.Components
             if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
             {
                 new CustomEvent("c3d.user.exited.boundary").Send();
-                exited = true;
-            }
-            else
-            {
-                exited = false;
             }
         }
 #endif

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -54,6 +54,7 @@ namespace Cognitive3D.Components
         private bool HasBoundaryChanged(Vector3[] previousBoundary, Vector3[] currentBoundary)
         {
             if ((previousBoundary == null && currentBoundary != null) || (previousBoundary != null && currentBoundary == null)) { return true; }
+            if (previousBoundary == null && currentBoundary == null) { return false; }
             if (previousBoundary.Length != currentBoundary.Length) { return true; }
 
             for (int i = 0; i < previousBoundary.Length; i++)

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using OVR.OpenVR;
+using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -192,7 +193,10 @@ namespace Cognitive3D.Components
 #if C3D_STEAMVR2
         private void OnChaperoneChanged(Valve.VR.VREvent_t arg0)
         {
-            if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
+            Valve.VR.HmdQuad_t[] steamVRPointsArray;
+            Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
+
+            if (setup.GetWorkingCollisionBoundsInfo(out steamVRPointsArray))
             {
                 new CustomEvent("c3d.user.exited.boundary").Send();
             }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.XR;
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-using TMPro;
+using UnityEngine.XR;
 
 /// <summary>
 /// Adds room size from SteamVR chaperone to device info
@@ -127,11 +127,11 @@ namespace Cognitive3D.Components
                 {
                     return boundaryPoints;
                 }
-
-                // Probably will return empty list; need to append with warning or somethings
-                return boundaryPoints;
             }
             // Unable to find boundary points - should we send an event?
+            // Probably will return empty list; need to append with warning or somethings
+            Debug.LogWarning("Unable to find boundary points using XRInputSubsystem");
+            return boundaryPoints;
 #endif
         }
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -90,7 +90,7 @@ namespace Cognitive3D.Components
             Transform trackingSpace = null;
             if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace))
             {
-                if (previousBoundaryPoints.Length != 0) // we want to avoid "fake exit" events if boundary points is empty array; this happens sometimes when you pause
+                if (previousBoundaryPoints != null && previousBoundaryPoints.Length != 0) // we want to avoid "fake exit" events if boundary points is empty array; this happens sometimes when you pause
                 {
                     if (!IsPointInPolygon4(previousBoundaryPoints, trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
                     {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -31,7 +31,6 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-
             currentTime += deltaTime;
             if (currentTime > BoundaryTrackingInterval)
             {
@@ -94,47 +93,47 @@ namespace Cognitive3D.Components
         /// <returns>A List of Vector3 representing the corners of the user defined boundary</returns>
         private List<Vector3> GetBoundaryPoints()
         {
-
-#if C3D_OCULUS
-        if (OVRManager.boundary == null)
-        {
-            return null;
-        }
-        boundaryPoints = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea).ToList();
-        return boundaryPoints;
-
-#elif C3D_STEAMVR2
-        // Valve.VR/OpenVR Array; we will convert it to list for ease of use
-        Valve.VR.HmdQuad_t[] steamVRBoundaryPoints;
-        Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
-        setup.GetWorkingCollisionBoundsInfo(out steamVRBoundaryPoints);
-        boundaryPoints = GetValveArrayAsList(steamVRBoundaryPoints);
-        //  Debug.Log(steamVRBoundaryPoints.Length);
-        // LogTheArray(steamVRBoundaryPoints);
-        return boundaryPoints;
-
-#else
-            // Using Unity's XRInputSubsystem as fallback
-            List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();
-            SubsystemManager.GetInstances<XRInputSubsystem>(subsystems);
-
-            // Handling case of multiple subsystems to find the first one that "works"
-            foreach (XRInputSubsystem subsystem in subsystems)
+            List <Vector3> retrievedPoints = new List<Vector3>();
+    #if C3D_OCULUS
+            if (OVRManager.boundary == null)
             {
-                if (!subsystem.running)
-                {
-                    continue;
-                }
-                if (subsystem.TryGetBoundaryPoints(boundaryPoints))
-                {
-                    return boundaryPoints;
-                }
+                return null;
             }
-            // Unable to find boundary points - should we send an event?
-            // Probably will return empty list; need to append with warning or somethings
-            Debug.LogWarning("Unable to find boundary points using XRInputSubsystem");
-            return boundaryPoints;
-#endif
+            retrievedPoints = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea).ToList();
+            return retrievedPoints;
+
+    #elif C3D_STEAMVR2
+            // Valve.VR/OpenVR Array; we will convert it to list for ease of use
+            Valve.VR.HmdQuad_t[] steamVRBoundaryPoints;
+            Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
+            setup.GetWorkingCollisionBoundsInfo(out steamVRBoundaryPoints);
+            retrievedPoints = GetValveArrayAsList(steamVRBoundaryPoints);
+            //  Debug.Log(steamVRBoundaryPoints.Length);
+            // LogTheArray(steamVRBoundaryPoints);
+            return retrievedPoints;
+
+    #else
+                // Using Unity's XRInputSubsystem as fallback
+                List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();
+                SubsystemManager.GetInstances<XRInputSubsystem>(subsystems);
+
+                // Handling case of multiple subsystems to find the first one that "works"
+                foreach (XRInputSubsystem subsystem in subsystems)
+                {
+                    if (!subsystem.running)
+                    {
+                        continue;
+                    }
+                    if (subsystem.TryGetBoundaryPoints(retrievedPoints))
+                    {
+                        return retrievedPoints;
+                    }
+                }
+                // Unable to find boundary points - should we send an event?
+                // Probably will return empty list; need to append with warning or somethings
+                Debug.LogWarning("Unable to find boundary points using XRInputSubsystem");
+                return retrievedPoints;
+    #endif
         }
 
         /// <summary>

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -99,7 +99,7 @@ namespace Cognitive3D.Components
         {
             return null;
         }
-        boundaryPoints = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea).ToList<Vector3>();
+        boundaryPoints = OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea).ToList();
         return boundaryPoints;
 
 #elif C3D_STEAMVR2

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -53,7 +53,7 @@ namespace Cognitive3D.Components
             List<Vector3> temporaryList = GetBoundaryPoints();
             for (int i = 0; i < boundaryPoints.Count; i++)
             {
-                if (Vector3.SqrMagnitude(boundaryPoints[i] - temporaryList[i]) >= 1)
+                if (Vector3.SqrMagnitude(boundaryPoints[i] - temporaryList[i]) >= 0.1)
                 {
                     return true;
                 }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -189,6 +189,22 @@ namespace Cognitive3D.Components
             return !GameplayReferences.SDKSupportsRoomSize;
         }
 
+#if C3D_STEAMVR2
+        private void OnChaperoneChanged(Valve.VR.VREvent_t arg0)
+        {
+            if (Valve.VR.OpenVR.Chaperone.AreBoundsVisible())
+            {
+                new CustomEvent("c3d.user.exited.boundary").Send();
+                exited = true;
+            }
+            else
+            {
+                exited = false;
+            }
+        }
+#endif
+
+
         public override string GetDescription()
         {
             if (GameplayReferences.SDKSupportsRoomSize)

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -24,10 +24,11 @@ namespace Cognitive3D.Components
             base.OnSessionBegin();
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
-
             previousBoundaryPoints = GetCurrentBoundaryPoints();
-            GameplayReferences.GetRoomSize(ref lastRoomSize);
             CalculateAndRecordRoomsize(false, false);
+            Vector3 initialRoomsize = new Vector3();
+            GameplayReferences.GetRoomSize(ref initialRoomsize);
+            WriteRoomSizeAsSessionProperty(initialRoomsize);
         }
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
@@ -60,7 +61,7 @@ namespace Cognitive3D.Components
             for (int i = 0; i < previousBoundary.Length; i++)
             {
                 // Check whether x or z coordinate changed significantly
-                // Ignore y because y is "up"
+                // Ignore y because y is "up" and boundary is infinitely high
                 // We only care about ground plane
                 if (Mathf.Abs(previousBoundary[i].x - currentBoundary[i].x) >= 0.1f
                     || Mathf.Abs(previousBoundary[i].z - currentBoundary[i].z) >= 0.1f)
@@ -174,6 +175,15 @@ namespace Cognitive3D.Components
             return result;
         }
 
+        /// <summary>
+        /// Writes roomsize as session property
+        /// </summary>
+        private void WriteRoomSizeAsSessionProperty(Vector3 roomsize)
+        {
+            Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeMeters", roomsize.x * roomsize.z);
+            Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} x {1:0.0}", roomsize.x, roomsize.z));
+        }
+
         //TODO pass in boundary points and record roomsize with that instead of using GameplayReferences method
 
         /// <summary>
@@ -206,8 +216,7 @@ namespace Cognitive3D.Components
                     }
                     else
                     {
-                        Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeMeters", roomsize.x * roomsize.z);
-                        Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} x {1:0.0}", roomsize.x, roomsize.z));
+                        WriteRoomSizeAsSessionProperty(roomsize);
                         SensorRecorder.RecordDataPoint("RoomSize", roomsize.x * roomsize.z);
                         if (recordRoomSizeChangeAsEvent)
                         {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -90,17 +90,20 @@ namespace Cognitive3D.Components
             Transform trackingSpace = null;
             if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace))
             {
-                if ((previousBoundaryPoints.Length != 0) && (!IsPointInPolygon4(previousBoundaryPoints, trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position))))
+                if (previousBoundaryPoints.Length != 0) // we want to avoid "fake exit" events if boundary points is empty array; this happens sometimes when you pause
                 {
-                    if (!isHMDOutsideBoundary)
+                    if (!IsPointInPolygon4(previousBoundaryPoints, trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
                     {
-                        new CustomEvent("c3d.user.exited.boundary").Send();
-                        isHMDOutsideBoundary = true;
+                        if (!isHMDOutsideBoundary)
+                        {
+                            new CustomEvent("c3d.user.exited.boundary").Send();
+                            isHMDOutsideBoundary = true;
+                        }
                     }
-                }
-                else
-                {
-                    isHMDOutsideBoundary = false;
+                    else
+                    {
+                        isHMDOutsideBoundary = false;
+                    }
                 }
             }
             else

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -54,7 +54,11 @@ namespace Cognitive3D.Components
             List<Vector3> temporaryList = GetBoundaryPoints();
             for (int i = 0; i < boundaryPoints.Count; i++)
             {
-                if (Vector3.SqrMagnitude(boundaryPoints[i] - temporaryList[i]) >= 0.1)
+                // Check whether x or z coordinate changed significantly
+                // Ignore y because y is "up"
+                // We only care about ground plane
+                if (Mathf.Abs(boundaryPoints[i].x - temporaryList[i].x) >= 0.1
+                    || Mathf.Abs(boundaryPoints[i].z - temporaryList[i].z) >= 0.1)
                 {
                     return true;
                 }
@@ -84,7 +88,7 @@ namespace Cognitive3D.Components
             }
             else
             {
-                // Tracking space unavailable: Maybe send an event or property?
+                Debug.LogWarning("Tracking Space not available");
             }
         }
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -166,6 +166,7 @@ namespace Cognitive3D.Components
         /// Sets the new roomsize as a session property and if the bool param is true, records the boundary change as a custom event
         /// </summary>
         /// <param name="recordRoomSizeChangeAsEvent">Flag to enable recording a custom event</param>
+        /// <param name="recordRecenterAsEvent">Flag to enable recording recenter</param>
         private void CalculateAndRecordRoomsize(bool recordRoomSizeChangeAsEvent, bool recordRecenterAsEvent)
         {
             Vector3 roomsize = new Vector3();

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -181,7 +181,9 @@ namespace Cognitive3D.Components
                     // We have determined that a recenter causes change in boundary points without chaning the roomsize
                     if (Mathf.Approximately(currentArea, lastArea))
                     {
-                        new CustomEvent("User recentered").Send();
+                        new CustomEvent("c3d.User recentered")
+                            .SetProperty("HMD position", GameplayReferences.HMD.position)
+                            .Send();
                     }
                     else
                     {
@@ -190,11 +192,14 @@ namespace Cognitive3D.Components
                         SensorRecorder.RecordDataPoint("RoomSize", roomsize.x * roomsize.z);
                         if (recordRoomSizeChangeAsEvent)
                         {
-                            new CustomEvent("c3d.User changed boundary").SetProperties(new Dictionary<string, object>
-                            {
-                                {  "Previous Room Size" , lastRoomSize.x * lastRoomSize.z },
-                                {   "New Room Size" , roomsize.x * roomsize.z }
-                            }).Send();
+                            new CustomEvent("c3d.User changed boundary")
+                            .SetProperties(
+                                new Dictionary<string, object>
+                                {
+                                    {  "Previous Room Size" , lastRoomSize.x * lastRoomSize.z },
+                                    {   "New Room Size" , roomsize.x * roomsize.z }
+                                })
+                            .Send();
                         }
                         lastRoomSize = roomsize;
                     }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -175,18 +175,29 @@ namespace Cognitive3D.Components
                 if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsSpatialDataAllowed)
 #endif
                 {
-                    Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeMeters", roomsize.x * roomsize.z);
-                    Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} x {1:0.0}", roomsize.x, roomsize.z));
-                    SensorRecorder.RecordDataPoint("RoomSize", roomsize.x * roomsize.z);
-                    if (recordRoomSizeChangeAsEvent)
+                    float currentArea = roomsize.x * roomsize.z;
+                    float lastArea = lastRoomSize.x * lastRoomSize.z;
+
+                    // We have determined that a recenter causes change in boundary points without chaning the roomsize
+                    if (Mathf.Approximately(currentArea, lastArea))
                     {
-                        new CustomEvent("c3d.User changed boundary").SetProperties(new Dictionary<string, object>
-                        {
-                            {  "Previous Room Size" , lastRoomSize.x * lastRoomSize.z },
-                            {   "New Room Size" , roomsize.x * roomsize.z }
-                        }).Send();
+                        new CustomEvent("User recentered").Send();
                     }
-                    lastRoomSize = roomsize;
+                    else
+                    {
+                        Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeMeters", roomsize.x * roomsize.z);
+                        Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} x {1:0.0}", roomsize.x, roomsize.z));
+                        SensorRecorder.RecordDataPoint("RoomSize", roomsize.x * roomsize.z);
+                        if (recordRoomSizeChangeAsEvent)
+                        {
+                            new CustomEvent("c3d.User changed boundary").SetProperties(new Dictionary<string, object>
+                            {
+                                {  "Previous Room Size" , lastRoomSize.x * lastRoomSize.z },
+                                {   "New Room Size" , roomsize.x * roomsize.z }
+                            }).Send();
+                        }
+                        lastRoomSize = roomsize;
+                    }
                 }
             }
             else

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -37,7 +37,6 @@ namespace Cognitive3D.Components
             if (currentTime > BoundaryTrackingInterval)
             {
                 currentTime = 0;
-
                 var currentBoundaryPoints = GetCurrentBoundaryPoints();
                 if (HasBoundaryChanged(previousBoundaryPoints, currentBoundaryPoints))
                 {
@@ -51,9 +50,15 @@ namespace Cognitive3D.Components
         /// <summary>
         /// Compares two lists of points to determine if the boundary changed
         /// </summary>
+        /// <param name="currentBoundary">The newly retrieved set of boundary points</param>
+        /// <param name="previousBoundary">The cached set of boundary points</param>
         /// <returns>True if boundary changed, false otherwise</returns>
         private bool HasBoundaryChanged(Vector3[] previousBoundary, Vector3[] currentBoundary)
         {
+            // this is for a very specific case where boundary exit sometimes causes an empty array from GetBoundaryPoints and hence "fake recenter" events
+            // better to have false negative than a false positive
+            if ((previousBoundary.Length > 0) && (currentBoundary.Length == 0)) {  return false; }
+
             if ((previousBoundary == null && currentBoundary != null) || (previousBoundary != null && currentBoundary == null)) { return true; }
             if (previousBoundary == null && currentBoundary == null) { return false; }
             if (previousBoundary.Length != currentBoundary.Length) { return true; }

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -39,7 +39,7 @@ namespace Cognitive3D.Components
                 currentTime = 0;
 
                 var currentBoundaryPoints = GetCurrentBoundaryPoints();
-                if (HasBoundaryChanged(previousBoundaryPoints,currentBoundaryPoints))
+                if (HasBoundaryChanged(previousBoundaryPoints, currentBoundaryPoints))
                 {
                     previousBoundaryPoints = currentBoundaryPoints;
                     CalculateAndRecordRoomsize(true, true);
@@ -80,7 +80,7 @@ namespace Cognitive3D.Components
             Transform trackingSpace = null;
             if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace))
             {
-                if (!IsPointInPolygon4(previousBoundaryPoints, trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
+                if ((previousBoundaryPoints.Length != 0) && (!IsPointInPolygon4(previousBoundaryPoints, trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position))))
                 {
                     if (!isHMDOutsideBoundary)
                     {
@@ -110,9 +110,6 @@ namespace Cognitive3D.Components
             {
                 return null;
             }
-
-            // GetGeometry returns an array but we are using lists
-            // Writing this code ourselves is better than importing a whole library just for one functions
             return OVRManager.boundary.GetGeometry(OVRBoundary.BoundaryType.PlayArea);
 
 #elif C3D_STEAMVR2

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -12,7 +12,7 @@ namespace Cognitive3D.Components
     public class RoomSize : AnalyticsComponentBase
     {
         List <Vector3> boundaryPoints = new List<Vector3>();
-        float BoundaryTrackingInterval = 1;
+        readonly float BoundaryTrackingInterval = 1;
         Vector3 lastRoomSize = new Vector3();
         bool exited;
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -71,7 +71,7 @@ namespace Cognitive3D.Components
         void SendEventIfUserExitsBoundary()
         {
             Transform trackingSpace = null;
-            if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(ref trackingSpace))
+            if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace))
             {
                 if (!IsPointInPolygon4(boundaryPoints.ToArray(), trackingSpace.transform.InverseTransformPoint(GameplayReferences.HMD.position)))
                 {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -43,7 +43,6 @@ namespace Cognitive3D.Components
             GetRoomSize(ref initialRoomsize);
             WriteRoomSizeAsSessionProperty(initialRoomsize);
 
-
 #if C3D_VIVEWAVE
             SystemEvent.Listen(WVR_EventType.WVR_EventType_ArenaChanged, ArenaChanged);
             SystemEvent.Listen(WVR_EventType.WVR_EventType_RecenterSuccess, Recenter);
@@ -478,9 +477,14 @@ namespace Cognitive3D.Components
         {
             Cognitive3D_Manager.OnUpdate -= Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+
+#if C3D_VIVEWAVE
+            SystemEvent.Remove(WVR_EventType.WVR_EventType_ArenaChanged, ArenaChanged);
+            SystemEvent.Remove(WVR_EventType.WVR_EventType_RecenterSuccess, Recenter);
+#endif
         }
 
-#region Inspector Utils
+    #region Inspector Utils
         public override bool GetWarning()
         {
             return !GameplayReferences.SDKSupportsRoomSize;

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -225,13 +225,16 @@ namespace Cognitive3D.Components
         /// <summary>
         /// Writes roomsize as session property
         /// </summary>
+        /// <param name="roomsize">A Vector3 representing the roomsize to write</param> 
         private void WriteRoomSizeAsSessionProperty(Vector3 roomsize)
         {
             Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeMeters", roomsize.x * roomsize.z);
             Cognitive3D_Manager.SetSessionProperty("c3d.roomsizeDescriptionMeters", string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.0} x {1:0.0}", roomsize.x, roomsize.z));
         }
 
-
+        /// <summary>
+        /// Sends a custom event indicating a recenter
+        /// </summary>
         private void SendRecenterEvent()
         {
             new CustomEvent("c3d.User recentered")
@@ -239,6 +242,10 @@ namespace Cognitive3D.Components
                 .Send();
         }
 
+        /// <summary>
+        /// Sends a custom event indicating change in boundary
+        /// </summary>
+        /// <param name="roomSizeRef">A Vector3 representing new roomsize</param>
         private void SendBoundaryChangeEvent(Vector3 roomSizeRef)
         {     
             // Chain SetProperty() instead of one SetProperties() to avoid creating dictionary and garbage
@@ -248,6 +255,9 @@ namespace Cognitive3D.Components
             .Send();
         }
 
+        /// <summary>
+        /// Sends a custom event indicating user stepping out of boundary
+        /// </summary>
         void SendExitEvent()
         {
             if (!isHMDOutsideBoundary)
@@ -447,6 +457,10 @@ namespace Cognitive3D.Components
         #endregion
 
 #if C3D_VIVEWAVE
+        /// <summary>
+        /// Vive Wave Specific: The function to execute when user changes their boundary
+        /// </summary>
+        /// <param name="arenaChangeEvent">The event that triggered this</param>
         void ArenaChanged(WVR_Event_t arenaChangeEvent)
         {
             if (!didViveArenaChange)

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -11,12 +11,9 @@ using UnityEngine.XR;
 
 /// <summary>
 /// Adds room size from VR boundary to the session properties
-/// Records a sensor
-/// On Oculus, also records events when boundary changes (ie, redrawn)
+/// Records room size as a sensor
+/// Sends event on boundary exit, redraw, and recenter
 /// </summary>
-
-
-
 namespace Cognitive3D.Components
 {
     [AddComponentMenu("Cognitive3D/Components/Room Size")]

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -182,9 +182,12 @@ namespace Cognitive3D.Components
                     // We have determined that a recenter causes change in boundary points without chaning the roomsize
                     if (Mathf.Approximately(currentArea, lastArea))
                     {
-                        new CustomEvent("c3d.User recentered")
+                        if (recordRecenterAsEvent)
+                        {
+                            new CustomEvent("c3d.User recentered")
                             .SetProperty("HMD position", GameplayReferences.HMD.position)
                             .Send();
+                        }
                     }
                     else
                     {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -11,9 +11,6 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Room Size")]
     public class RoomSize : AnalyticsComponentBase
     {
-        // TESTING
-        public Transform trackingSpace;
-
         List <Vector3> boundaryPoints = new List<Vector3>();
         float BoundaryTrackingInterval = 1;
         Vector3 lastRoomSize = new Vector3();
@@ -68,9 +65,9 @@ namespace Cognitive3D.Components
         /// </summary>
         void SendEventIfUserExitsBoundary()
         {
-            if (trackingSpace != null)
+            if (Cognitive3D_Manager.Instance.TrackingSpace != null)
             {
-                if (!IsPointInPolygon4(boundaryPoints.ToArray(), trackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
+                if (!IsPointInPolygon4(boundaryPoints.ToArray(), Cognitive3D_Manager.Instance.TrackingSpace.InverseTransformPoint(GameplayReferences.HMD.position)))
                 {
                     if (!exited)
                     {

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -26,7 +26,7 @@ namespace Cognitive3D.Components
             boundaryPoints = GetBoundaryPoints();
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
-            CalculateAndRecordRoomsize(false);
+            CalculateAndRecordRoomsize(false, false);
         }
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
@@ -37,7 +37,7 @@ namespace Cognitive3D.Components
                 if (HasBoundaryChanged())
                 {
                     boundaryPoints = GetBoundaryPoints();
-                    CalculateAndRecordRoomsize(true);
+                    CalculateAndRecordRoomsize(true, true);
                 }
                 SendEventIfUserExitsBoundary();
                 currentTime = 0;
@@ -166,7 +166,7 @@ namespace Cognitive3D.Components
         /// Sets the new roomsize as a session property and if the bool param is true, records the boundary change as a custom event
         /// </summary>
         /// <param name="recordRoomSizeChangeAsEvent">Flag to enable recording a custom event</param>
-        private void CalculateAndRecordRoomsize(bool recordRoomSizeChangeAsEvent)
+        private void CalculateAndRecordRoomsize(bool recordRoomSizeChangeAsEvent, bool recordRecenterAsEvent)
         {
             Vector3 roomsize = new Vector3();
             if (GameplayReferences.GetRoomSize(ref roomsize))

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -11,6 +11,8 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Room Size")]
     public class RoomSize : AnalyticsComponentBase
     {
+
+        public GameObject post;
         
         //counts up the deltatime to determine when the interval ends
         private float currentTime;
@@ -47,6 +49,31 @@ namespace Cognitive3D.Components
             }
 #endif
             CalculateAndRecordRoomsize(false);
+        }
+
+        float time;
+        private void Update()
+        {
+            Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
+            Valve.VR.HmdQuad_t steamVRPoint = new Valve.VR.HmdQuad_t();
+            setup.GetWorkingPlayAreaRect(ref steamVRPoint);
+            time = Time.time;
+
+            if (Time.time > time + 5)
+            {
+                Instantiate(post, SteamToVector(steamVRPoint.vCorners0), new Quaternion());
+                Instantiate(post, SteamToVector(steamVRPoint.vCorners1), new Quaternion());
+                Instantiate(post, SteamToVector(steamVRPoint.vCorners2), new Quaternion());
+                Instantiate(post, SteamToVector(steamVRPoint.vCorners3), new Quaternion());
+                time = Time.time;
+            }
+           
+        }
+
+        private Vector3 SteamToVector(Valve.VR.HmdVector3_t point)
+        {
+            Vector3 myPoint = new Vector3(point.v0, point.v1, point.v2);
+            return myPoint;
         }
 
 #if C3D_OCULUS
@@ -193,13 +220,13 @@ namespace Cognitive3D.Components
 #if C3D_STEAMVR2
         private void OnChaperoneChanged(Valve.VR.VREvent_t arg0)
         {
-            Valve.VR.HmdQuad_t[] steamVRPointsArray;
+/*            Valve.VR.HmdQuad_t[] steamVRPointsArray;
             Valve.VR.CVRChaperoneSetup setup = Valve.VR.OpenVR.ChaperoneSetup;
 
             if (setup.GetWorkingCollisionBoundsInfo(out steamVRPointsArray))
             {
                 new CustomEvent("c3d.user.exited.boundary").Send();
-            }
+            }*/
         }
 #endif
 

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -23,6 +23,7 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
+            boundaryPoints = GetBoundaryPoints();
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             CalculateAndRecordRoomsize(false);

--- a/Runtime/Components/RoomTrackingSpace.cs
+++ b/Runtime/Components/RoomTrackingSpace.cs
@@ -1,18 +1,11 @@
-using Cognitive3D;
 using UnityEngine;
 
 /// <summary>
-/// This is meant to be a class that only sets a variable in Cognitive3D_Manager - it does nothing else
-/// The code in Start() is here as opposed to Cognitive3D_Manager because we want it to work with objects that spawn later
-/// This will be added to the TrackingSpace or equivalent GameObject so it can be identified and found at runtime
+/// This is meant to be an empty class so we can find it using FindObjectOfType<>
 /// </summary>
-/// 
 
 [DisallowMultipleComponent]
 public class RoomTrackingSpace : MonoBehaviour
 {
-    private void Start()
-    {
-        Cognitive3D_Manager.Instance.trackingSpace = this.gameObject;
-    }
+
 }

--- a/Runtime/Components/RoomTrackingSpace.cs
+++ b/Runtime/Components/RoomTrackingSpace.cs
@@ -1,10 +1,18 @@
+using Cognitive3D;
 using UnityEngine;
 
 /// <summary>
-/// This is an EMPTY class and it is MEANT TO BE THAT WAY
+/// This is meant to be a class that only sets a variable in Cognitive3D_Manager - it does nothing else
+/// The code in Start() is here as opposed to Cognitive3D_Manager because we want it to work with objects that spawn later
 /// This will be added to the TrackingSpace or equivalent GameObject so it can be identified and found at runtime
 /// </summary>
+/// 
+
+[DisallowMultipleComponent]
 public class RoomTrackingSpace : MonoBehaviour
 {
-
+    private void Start()
+    {
+        Cognitive3D_Manager.Instance.trackingSpace = this.gameObject;
+    }
 }

--- a/Runtime/Components/RoomTrackingSpace.cs
+++ b/Runtime/Components/RoomTrackingSpace.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+/// <summary>
+/// This is an EMPTY class and it is MEANT TO BE THAT WAY
+/// This will be added to the TrackingSpace or equivalent GameObject so it can be identified and found at runtime
+/// </summary>
+public class RoomTrackingSpace : MonoBehaviour
+{
+
+}

--- a/Runtime/Components/RoomTrackingSpace.cs.meta
+++ b/Runtime/Components/RoomTrackingSpace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e04845c142b7b14ba36bfc7d22c5d82
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -414,6 +414,29 @@ namespace Cognitive3D
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);
         }
 
+        public bool TryGetTrackingSpace(ref Transform space)
+        {
+            if (trackingSpace != null)
+            {
+                space = trackingSpace.transform;
+                return true;
+            }
+            else
+            {
+                GameObject trackingSpaceInScene = FindFirstObjectByType<RoomTrackingSpace>().gameObject;
+                if (trackingSpaceInScene != null)
+                {
+                    trackingSpace = trackingSpaceInScene;
+                    space = trackingSpaceInScene.transform;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
         private void SceneManager_SceneUnloaded(Scene scene)
         {
             if (DoesSceneHaveID(scene))

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -60,6 +60,23 @@ namespace Cognitive3D
 
         private readonly List<Scene> sceneList = new List<Scene>();
 
+        #region TrackingSpace
+        private Transform trackingSpace;
+
+        public Transform TrackingSpace
+        {
+            get
+            {
+                return trackingSpace;
+            }
+
+            set
+            {
+                trackingSpace = value;
+            }
+        }
+        #endregion
+
         /// <summary>
         /// sets instance of Cognitive3D_Manager
         /// </summary>

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -418,7 +418,7 @@ namespace Cognitive3D
         {
             if (trackingSpace != null)
             {
-                space = trackingSpace.transform;
+                space = trackingSpace;
                 return true;
             }
             else

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -414,7 +414,7 @@ namespace Cognitive3D
             InvokeLevelLoadedEvent(scene, mode, replacingSceneId);
         }
 
-        public bool TryGetTrackingSpace(ref Transform space)
+        public bool TryGetTrackingSpace(out Transform space)
         {
             if (trackingSpace != null)
             {
@@ -432,6 +432,7 @@ namespace Cognitive3D
                 }
                 else
                 {
+                    space = null;
                     return false;
                 }
             }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -60,23 +60,6 @@ namespace Cognitive3D
 
         private readonly List<Scene> sceneList = new List<Scene>();
 
-        #region TrackingSpace
-        private Transform trackingSpace;
-
-        public Transform TrackingSpace
-        {
-            get
-            {
-                return trackingSpace;
-            }
-
-            set
-            {
-                trackingSpace = value;
-            }
-        }
-        #endregion
-
         /// <summary>
         /// sets instance of Cognitive3D_Manager
         /// </summary>

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -61,7 +61,7 @@ namespace Cognitive3D
         private readonly List<Scene> sceneList = new List<Scene>();
 
         [HideInInspector]
-        public GameObject trackingSpace;
+        public Transform trackingSpace;
 
         /// <summary>
         /// sets instance of Cognitive3D_Manager
@@ -423,10 +423,10 @@ namespace Cognitive3D
             }
             else
             {
-                GameObject trackingSpaceInScene = FindFirstObjectByType<RoomTrackingSpace>().gameObject;
+                var trackingSpaceInScene = FindObjectOfType<RoomTrackingSpace>();
                 if (trackingSpaceInScene != null)
                 {
-                    trackingSpace = trackingSpaceInScene;
+                    trackingSpace = trackingSpaceInScene.transform;
                     space = trackingSpaceInScene.transform;
                     return true;
                 }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -60,6 +60,9 @@ namespace Cognitive3D
 
         private readonly List<Scene> sceneList = new List<Scene>();
 
+        [HideInInspector]
+        public GameObject trackingSpace;
+
         /// <summary>
         /// sets instance of Cognitive3D_Manager
         /// </summary>

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -27,7 +27,7 @@ namespace Cognitive3D
     [AddComponentMenu("Cognitive3D/Common/Cognitive 3D Manager",1)]
     public class Cognitive3D_Manager : MonoBehaviour
     {
-        public static readonly string SDK_VERSION = "1.3.6";
+        public static readonly string SDK_VERSION = "1.3.7";
     
         private static Cognitive3D_Manager instance;
         public static Cognitive3D_Manager Instance

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -147,6 +147,7 @@ namespace Cognitive3D
 
         ///x,y,z is width, height, depth
         ///return value is in meters
+        [System.Obsolete()]
         public static bool GetRoomSize(ref Vector3 roomSize)
         {
 #if C3D_STEAMVR2

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -147,7 +147,7 @@ namespace Cognitive3D
 
         ///x,y,z is width, height, depth
         ///return value is in meters
-        [System.Obsolete()]
+        [System.Obsolete]
         public static bool GetRoomSize(ref Vector3 roomSize)
         {
 #if C3D_STEAMVR2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.cognitive3d.c3d-sdk",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"displayName": "Cognitive3D Unity SDK",
 	"description": "Analytics Platform for VR/AR/MR",
 	"unity": "2019.4",


### PR DESCRIPTION
# Description

This change encapsulates the following:
- Fix for SteamVR boundary implementation
- Adding generic Unity XR API implementation for boundary
- Adding event for when user recenters
- Code cleanup

Requires heavy testing on Oculus, SteamVR, Unity Generic XR for boundary exits, boundary changes, and recenters.

Height Task ID (If applicable): https://c3d.height.app/T-3473  ||  https://c3d.height.app/T-4053

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules