### PR TITLE
Fix for Unity Export Dynamic Object count bug

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -1204,10 +1204,6 @@ namespace Cognitive3D
         /// </summary>
         public static List<string> GetExportedDynamicObjectNames()
         {
-            //cached value
-            if (ExportedDynamicObjects != null)
-                return ExportedDynamicObjects;
-
             //read dynamic object mesh names from directory
             string path = Directory.GetCurrentDirectory() + Path.DirectorySeparatorChar + "Cognitive3D_SceneExplorerExport" + Path.DirectorySeparatorChar + "Dynamic";
             Directory.CreateDirectory(path);


### PR DESCRIPTION
# Description

This PR includes the following changes:

- Fix for Unity Export Dynamic Object count bug
- Removed the cached value in EditorCore.cs

Height Task ID (If applicable): https://c3d.height.app/T-4420

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules