### PR TITLE
Removed access to internal monobehaviour scripts from Unity

### DIFF
--- a/Runtime/ActiveSessionView/Scripts/ActiveSessionView.cs
+++ b/Runtime/ActiveSessionView/Scripts/ActiveSessionView.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Active Session View")]
+    [AddComponentMenu("")]
     public class ActiveSessionView : MonoBehaviour
     {
         //sensor materials

--- a/Runtime/ActiveSessionView/Scripts/CopyVRViewToRenderTexture.cs
+++ b/Runtime/ActiveSessionView/Scripts/CopyVRViewToRenderTexture.cs
@@ -8,7 +8,7 @@ using UnityEngine.Rendering;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Copy VR View To Render Texture")]
+    [AddComponentMenu("")]
     public class CopyVRViewToRenderTexture : MonoBehaviour
     {
         Camera mainCamera;

--- a/Runtime/ActiveSessionView/Scripts/DataBatchCanvas.cs
+++ b/Runtime/ActiveSessionView/Scripts/DataBatchCanvas.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Data Batch Canvas")]
+    [AddComponentMenu("")]
     public class DataBatchCanvas : MonoBehaviour
     {
         public Text EventSendText;

--- a/Runtime/ActiveSessionView/Scripts/DynamicSortable.cs
+++ b/Runtime/ActiveSessionView/Scripts/DynamicSortable.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-	[AddComponentMenu("Cognitive3D/Active Session View/Dynamic Sortable")]
+	[AddComponentMenu("")]
 	public class DynamicSortable : MonoBehaviour
 	{
 		public int Sequence; //stored here in case list ever gets sorted to some different order

--- a/Runtime/ActiveSessionView/Scripts/EventCanvas.cs
+++ b/Runtime/ActiveSessionView/Scripts/EventCanvas.cs
@@ -8,7 +8,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Event Canvas")]
+    [AddComponentMenu("")]
     public class EventCanvas : MonoBehaviour
     {
         public RectTransform EventFeedRoot;

--- a/Runtime/ActiveSessionView/Scripts/EventFeedEntry.cs
+++ b/Runtime/ActiveSessionView/Scripts/EventFeedEntry.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Event Feed Entry")]
+    [AddComponentMenu("")]
     public class EventFeedEntry : MonoBehaviour
     {
         public Text Title;

--- a/Runtime/ActiveSessionView/Scripts/FullscreenDisplay.cs
+++ b/Runtime/ActiveSessionView/Scripts/FullscreenDisplay.cs
@@ -14,7 +14,7 @@ using Cognitive3D;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Fullscreen Display")]
+    [AddComponentMenu("")]
     public class FullscreenDisplay : MonoBehaviour
     {
         //ActiveSessionView Asv;

--- a/Runtime/ActiveSessionView/Scripts/MetaCanvas.cs
+++ b/Runtime/ActiveSessionView/Scripts/MetaCanvas.cs
@@ -9,7 +9,7 @@ namespace Cognitive3D
 {
     namespace ActiveSession
     {
-        [AddComponentMenu("Cognitive3D/Active Session View/Meta Canvas")]
+        [AddComponentMenu("")]
         public class MetaCanvas : MonoBehaviour
         {
             public Text CurrentSessionLength;

--- a/Runtime/ActiveSessionView/Scripts/RenderEyetracking.cs
+++ b/Runtime/ActiveSessionView/Scripts/RenderEyetracking.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Render Eyetracking")]
+    [AddComponentMenu("")]
     public class RenderEyetracking : MonoBehaviour
     {
         //reticle

--- a/Runtime/ActiveSessionView/Scripts/SensorCanvas.cs
+++ b/Runtime/ActiveSessionView/Scripts/SensorCanvas.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Sensor Canvas")]
+    [AddComponentMenu("")]
     public class SensorCanvas : MonoBehaviour
     {
         public struct SensorDataPoint

--- a/Runtime/ActiveSessionView/Scripts/SensorRenderCamera.cs
+++ b/Runtime/ActiveSessionView/Scripts/SensorRenderCamera.cs
@@ -8,7 +8,7 @@ using Cognitive3D;
 
 namespace Cognitive3D.ActiveSession
 {
-    [AddComponentMenu("Cognitive3D/Active Session View/Sensor Render Camera")]
+    [AddComponentMenu("")]
     public class SensorRenderCamera : MonoBehaviour
     {
         SensorCanvas sensorCanvas;


### PR DESCRIPTION
# Description

This PR includes the following changes:

- Hide internal monobehaviour scripts from Unity
- Add the [AddComponentMenu("")] attribute to the classes (Runtime/Internal and Runtime/ActiveSessionView related scripts)

Height Task ID (If applicable): https://c3d.height.app/T-3061

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published in downstream modules