### PR TITLE
Fixed Exception in OculusSocial

### DIFF
--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -36,22 +36,20 @@ namespace Cognitive3D.Components
                 try
                 {
                     Core.Initialize(appID);
+                    Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
+                    if (RecordPartySize)
+                    {
+                        CheckPartySize();
+                    }
                 }
                 catch (System.Exception e)
                 {
                     Debug.LogException(e);
                 }
             }
-
             if (!string.IsNullOrEmpty(appID))
             {
                 Cognitive3D_Manager.SetSessionProperty("c3d.app.oculus.appid", appID);
-            }
-
-            Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
-            if (RecordPartySize)
-            {
-                CheckPartySize();
             }
 #endif
         }

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 #if C3D_OCULUS
 using Oculus.Platform;
@@ -33,21 +31,25 @@ namespace Cognitive3D.Components
             if (!Core.IsInitialized())
             {
                 // Initialize will throw error if appid is invalid/missing
-                // IMPORTANT: To prevent exceptions, put all code that depends on successful initialization here
                 try
                 {
                     Core.Initialize(appID);
-                    Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
-                    if (RecordPartySize)
-                    {
-                        CheckPartySize();
-                    }
                 }
                 catch (System.Exception e)
                 {
                     Debug.LogException(e);
                 }
             }
+
+            if (Core.IsInitialized())
+            {
+                Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
+                if (RecordPartySize)
+                {
+                    CheckPartySize();
+                }
+            }
+
             if (!string.IsNullOrEmpty(appID))
             {
                 Cognitive3D_Manager.SetSessionProperty("c3d.app.oculus.appid", appID);
@@ -69,10 +71,11 @@ namespace Cognitive3D.Components
             }
         }
 
-        /**
-         * Callback for user Entitlement check
-         * @params: Message message: the response message
-         */ 
+        /// <summary>
+        /// Callback for entitlement check
+        /// Tries to get the logged in user and goes to the next callback
+        /// </summary>
+        /// <param name="message"> The response message </param>
         private void EntitlementCallback(Message message)
         {
             if (message.IsError) // User failed entitlement check
@@ -87,11 +90,12 @@ namespace Cognitive3D.Components
             }
         }
 #endif
-/**
- * Callback for getting details on the logged in user
- * @params: Message <User> message: The User object representing the current logged in user
- */
+
 #if C3D_OCULUS
+        /// <summary>
+        /// Callback for getting details on the logged in user
+        /// </summary>
+        /// <param name="message"> The User object representing the current logged in user </param>
         private void UserCallback(Message<User> message)
         {
             string id;
@@ -117,14 +121,14 @@ namespace Cognitive3D.Components
         }
 
 #endif
-/**
- * Callback to get the display name (apparently a second request 
- *          is needed to get display name, 
- *          as per here: 
- *          https://stackoverflow.com/questions/76038469/oculus-users-getloggedinuser-return-empty-string-for-displayname-field)
- *  @params: Message message: the response for the callback
- */
+
 #if C3D_OCULUS
+        /// <summary>
+        /// Callback to get the display name
+        /// apparently a second request is required
+        /// https://stackoverflow.com/questions/76038469/oculus-users-getloggedinuser-return-empty-string-for-displayname-field)
+        /// </summary>
+        /// <param name="message"> The response for the callback </param>
         private void DisplayNameCallback(Message message)
         {
             string displayName = message.GetUser().DisplayName;
@@ -141,9 +145,9 @@ namespace Cognitive3D.Components
         }
 #endif
 
-        /**
-         * Checks the number of people in the room/part
-         */ 
+        /// <summary>
+        /// Checks the number of people in the room/party
+        /// </summary>
         void CheckPartySize()
         {
 #if C3D_OCULUS
@@ -172,9 +176,11 @@ namespace Cognitive3D.Components
             });
 #endif
         }
-        /**
-         * Description to display in inspector
-         */ 
+
+        /// <summary>
+        /// Description to display in inspector
+        /// </summary>
+        /// <returns> A string representing the description </returns>
         public override string GetDescription()
         {
 #if C3D_OCULUS
@@ -184,9 +190,9 @@ namespace Cognitive3D.Components
 #endif
         }
 
-        /**
-         * Warning for incompatible platform to display on inspector
-         */ 
+        /// <summary>
+        /// Warning for incompatible platform to display on inspector
+        /// </summary>
         public override bool GetWarning()
         {
 #if C3D_OCULUS

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -32,7 +32,8 @@ namespace Cognitive3D.Components
             string appID = GetAppIDFromConfig();
             if (!Core.IsInitialized())
             {
-                //Initialize will throw error if appid is invalid/missing
+                // Initialize will throw error if appid is invalid/missing
+                // IMPORTANT: To prevent exceptions, put all code that depends on successful initialization here
                 try
                 {
                     Core.Initialize(appID);


### PR DESCRIPTION
# Description

`OculusSocial.cs` was causing exceptions if the platform initialization failed. This exception caused problems in serializing data, and caused sessions to be 0 seconds long. I moved some risky code (risky only in the sense that it can fail if initialization fails) into the `try` block. This seems to have fixed the issue.

Note: If initalization fails, not Oculus Social data will be collected, but at least we won't have the app record nothing. It will gracefully fail.

Height Task ID(s) (If applicable): https://c3d.height.app/T-4486

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
