### PR TITLE
Sensors and Events for Hands -vs- Controllers

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -21,6 +21,7 @@ namespace Cognitive3D
         bool wantEyeTrackingEnabled;
         bool wantPassthroughEnabled;
         bool wantSocialEnabled;
+        bool wantHandTrackingEnabled;
 #endif
 
         private const string URL_SESSION_TAGS_DOCS = "https://docs.cognitive3d.com/dashboard/session-tags/";
@@ -717,6 +718,26 @@ namespace Cognitive3D
                 }
             }
 
+            // Hand Tracking
+            GUI.Label(new Rect(140, 285, 440, 440), "Quest Hand Tracking", "normallabel");
+            Rect infoRect4 = new Rect(320, 280, 30, 30);
+            GUI.Label(infoRect4, new GUIContent(EditorCore.Info, "Collects and sends data pertaining to Hand Trackings ."), "image_centered");
+
+            Rect checkboxRect4 = new Rect(105, 280, 30, 30);
+            if (wantHandTrackingEnabled)
+            {
+                if (GUI.Button(checkboxRect4, EditorCore.BoxCheckmark, "image_centered"))
+                {
+                    wantHandTrackingEnabled = false;
+                }
+            }
+            else
+            {
+                if (GUI.Button(checkboxRect4, EditorCore.BoxEmpty, "image_centered"))
+                {
+                    wantHandTrackingEnabled = true;
+                }
+            }
 
             // Footer
             GUI.Label(new Rect(20, 460, 440, 440), "*Recommended for publishing to the Meta App Store", "caption");
@@ -769,6 +790,23 @@ namespace Cognitive3D
                     DestroyImmediate(social);
                 }
             }
+            if (wantHandTrackingEnabled)
+            {
+                var hand = FindObjectOfType<HandTracking>();
+                if (hand == null)
+                {
+                    Cognitive3D_Manager.Instance.gameObject.AddComponent<HandTracking>();
+                }
+            }
+            else
+            {
+                var hand = FindObjectOfType<HandTracking>();
+                if (hand != null)
+                {
+                    DestroyImmediate(hand);
+                }
+            }
+
         }   
 #endif
 

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 namespace Cognitive3D.Components
 {
     [AddComponentMenu("Cognitive3D/Components/Hand Tracking")]
+    [DisallowMultipleComponent]
     public class HandTracking : AnalyticsComponentBase
     {
 #if C3D_OCULUS

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+
+namespace Cognitive3D.Components
+{
+    [AddComponentMenu("Cognitive3D/Components/Hand Tracking")]
+    public class HandTracking : AnalyticsComponentBase
+    {
+#if C3D_OCULUS
+        /// <summary>
+        /// Represents participant is using hands, controller, or neither
+        /// </summary>
+        private enum TrackingType
+        {
+            None = 0,
+            Controller = 1,
+            Hand = 2
+        }
+
+        private TrackingType lastTrackedDevice = TrackingType.None;
+
+        protected override void OnSessionBegin()
+        {
+            base.OnSessionBegin();
+            lastTrackedDevice = GetCurrentTrackedDevice();
+            Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", true);
+            Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
+            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+        }
+
+        private void Cognitive3D_Manager_OnUpdate(float deltaTime)
+        {
+            CaptureHandTrackingEvents();
+            SensorRecorder.RecordDataPoint("c3d.input.device", (int)GetCurrentTrackedDevice());
+        }
+
+        /// <summary>
+        /// Gets the current tracked device i.e. hand or controller
+        /// </summary>
+        /// <returns> Enum representing whether user is using hand or controller or neither </returns>
+        TrackingType GetCurrentTrackedDevice()
+        {
+            if (OVRInput.GetActiveController() == OVRInput.Controller.None)
+            {
+                return TrackingType.None;
+            }
+            else if (OVRInput.GetActiveController() == OVRInput.Controller.Hands
+                || OVRInput.GetActiveController() == OVRInput.Controller.LHand
+                || OVRInput.GetActiveController() == OVRInput.Controller.RHand)
+            {
+                return TrackingType.Hand;
+            }
+            else
+            {
+                return TrackingType.Controller;
+            }
+        }
+
+        /// <summary>
+        /// Captures any change in input device from hand to controller to none or vice versa
+        /// </summary>
+        void CaptureHandTrackingEvents()
+        {
+            if (lastTrackedDevice != GetCurrentTrackedDevice())
+            {
+                new CustomEvent("c3d.input.tracking.device.changed.from." + lastTrackedDevice.ToString() + ".to." + GetCurrentTrackedDevice()).Send();
+                lastTrackedDevice = GetCurrentTrackedDevice();
+            }
+        }
+
+        private void Cognitive3D_Manager_OnPreSessionEnd()
+        {
+            Cognitive3D_Manager.OnUpdate -= Cognitive3D_Manager_OnUpdate;
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+        }
+#endif
+
+        #region Inspector Utils
+        public override bool GetWarning()
+        {
+#if C3D_OCULUS
+            return false;
+#else
+            return true;
+#endif
+        }
+
+        public override string GetDescription()
+        {
+#if C3D_OCULUS
+            return "Collects and sends data pertaining to Hand Tracking";
+#else
+            return "This component can only be used on the Oculus platform"
+#endif
+        }
+#endregion
+
+    }
+}

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -30,8 +30,9 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-            CaptureHandTrackingEvents();
-            SensorRecorder.RecordDataPoint("c3d.input.device", (int)GetCurrentTrackedDevice());
+            var currentTrackedDevice = GetCurrentTrackedDevice();
+            CaptureHandTrackingEvents(currentTrackedDevice);
+            SensorRecorder.RecordDataPoint("c3d.input.tracking", (int) currentTrackedDevice);
         }
 
         /// <summary>
@@ -40,13 +41,14 @@ namespace Cognitive3D.Components
         /// <returns> Enum representing whether user is using hand or controller or neither </returns>
         TrackingType GetCurrentTrackedDevice()
         {
-            if (OVRInput.GetActiveController() == OVRInput.Controller.None)
+            var currentTrackedDevice = OVRInput.GetActiveController();
+            if (currentTrackedDevice == OVRInput.Controller.None)
             {
                 return TrackingType.None;
             }
-            else if (OVRInput.GetActiveController() == OVRInput.Controller.Hands
-                || OVRInput.GetActiveController() == OVRInput.Controller.LHand
-                || OVRInput.GetActiveController() == OVRInput.Controller.RHand)
+            else if (currentTrackedDevice == OVRInput.Controller.Hands
+                || currentTrackedDevice == OVRInput.Controller.LHand
+                || currentTrackedDevice == OVRInput.Controller.RHand)
             {
                 return TrackingType.Hand;
             }
@@ -59,12 +61,15 @@ namespace Cognitive3D.Components
         /// <summary>
         /// Captures any change in input device from hand to controller to none or vice versa
         /// </summary>
-        void CaptureHandTrackingEvents()
+        void CaptureHandTrackingEvents(TrackingType currentTrackedDevice)
         {
-            if (lastTrackedDevice != GetCurrentTrackedDevice())
+            if (lastTrackedDevice != currentTrackedDevice)
             {
-                new CustomEvent("c3d.input.tracking.device.changed.from." + lastTrackedDevice.ToString() + ".to." + GetCurrentTrackedDevice()).Send();
-                lastTrackedDevice = GetCurrentTrackedDevice();
+                new CustomEvent("c3d.input.tracking.changed")
+                    .SetProperty("Previously Tracking", lastTrackedDevice)
+                    .SetProperty("Now Tracking", currentTrackedDevice)
+                    .Send();
+                lastTrackedDevice = currentTrackedDevice;
             }
         }
 

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -89,7 +89,7 @@ namespace Cognitive3D.Components
 #if C3D_OCULUS
             return "Collects and sends data pertaining to Hand Tracking";
 #else
-            return "This component can only be used on the Oculus platform"
+            return "This component can only be used on the Oculus platform";
 #endif
         }
 #endregion

--- a/Runtime/Components/HandTracking.cs.meta
+++ b/Runtime/Components/HandTracking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9e5de26c573d7c418f6d02298be0174
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Incrementally building towards hand tracking support, we are sending sensors for whether participant is using hands, controllers, or none. We are also sending events when they switch between hands and controllers.

For the sensors:
- 0 = None
- 1 = Controller
- 2 = Hand

Session with example: https://app.cognitive3d.com/scenes/3fdf2fd6-4d2d-405b-b638-d6d619ebcc96/v/19/session/1201395
https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/d8221a17-4303-4f78-bf47-8ddbdf2aa87b

Height Task ID(s) (If applicable): https://c3d.height.app/T-4643

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
