### PR TITLE
Fix for incorrect HMD yaw calculation

### DIFF
--- a/Runtime/Components/HMDOrientation.cs
+++ b/Runtime/Components/HMDOrientation.cs
@@ -11,10 +11,13 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/HMDOrientation")]
     public class HMDOrientation : AnalyticsComponentBase
     {
+        Transform trackingSpace = null;
+
         protected override void OnSessionBegin()
         {
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+            Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace);
         }
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
@@ -35,11 +38,29 @@ namespace Cognitive3D.Components
             SensorRecorder.RecordDataPoint("c3d.hmd.pitch", pitch);
         }
 
-        //records yaw with 0 as the center and 180 as directly behind the player (from the starting position)
+        /// <summary>
+        /// Calculates yaw of hmd/users neck
+        /// Positive means looking right, negative means looking left
+        /// </summary>
         private void RecordYaw()
         {
             if (GameplayReferences.HMD == null) { return; }
-            float yaw = GameplayReferences.HMD.localRotation.eulerAngles.y;
+            if (trackingSpace == null)
+            {
+                Debug.LogWarning("TrackingSpace not configured. Unable to record HMD Yaw");
+                return;
+            }
+
+            // Start with quaternions to calculate rotation
+            Quaternion hmdRotation = GameplayReferences.HMD.rotation;
+            Quaternion trackingSpaceRotation = trackingSpace.transform.rotation;
+
+            // Adjust rotations to "isolate" HMD rotation from trackingSpace rotation
+            Quaternion adjustedRotation = Quaternion.Inverse(trackingSpaceRotation) * hmdRotation;
+
+            float yaw = adjustedRotation.eulerAngles.y;
+
+            // Take smaller angle of the explementary angles
             if (yaw > 180)
             {
                 yaw -= 360;

--- a/Runtime/Components/HMDOrientation.cs
+++ b/Runtime/Components/HMDOrientation.cs
@@ -11,7 +11,7 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/HMDOrientation")]
     public class HMDOrientation : AnalyticsComponentBase
     {
-        Transform trackingSpace = null;
+        Transform trackingSpace;
 
         protected override void OnSessionBegin()
         {


### PR DESCRIPTION
# Description

This PR includes the following changes:

- Calculates the yaw value according to the tracking space
- Calculation fix for recording yaw by isolating HMD rotation from tracking space rotation

Height Task ID(s) (If applicable): https://c3d.height.app/T-4190

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
