### PR TITLE
Using scripting symbols for `ProfilerRecorder`. Only available for Unity >= 2020.2

### DIFF
--- a/Runtime/Components/ProfilerSensor.cs
+++ b/Runtime/Components/ProfilerSensor.cs
@@ -5,6 +5,7 @@ namespace Cognitive3D
 {
     public class ProfilerSensor : AnalyticsComponentBase
     {
+#if UNITY_2020_2_OR_NEWER
         private ProfilerRecorder drawCallsRecorder;
         private ProfilerRecorder systemMemoryRecorder;
         private ProfilerRecorder mainThreadTimeRecorder;
@@ -63,5 +64,6 @@ namespace Cognitive3D
         }
 #endregion
 
+#endif
     }
 }

--- a/Runtime/Components/ProfilerSensor.cs
+++ b/Runtime/Components/ProfilerSensor.cs
@@ -5,6 +5,8 @@ namespace Cognitive3D
 {
     public class ProfilerSensor : AnalyticsComponentBase
     {
+        // This API doesn't exist for lower versions
+        // https://docs.unity3d.com/ScriptReference/Unity.Profiling.ProfilerRecorder.html
 #if UNITY_2020_2_OR_NEWER
         private ProfilerRecorder drawCallsRecorder;
         private ProfilerRecorder systemMemoryRecorder;


### PR DESCRIPTION
# Description

Testing with Unity 2019.4 revealed that the ProfilerRecorder only exists above 2020.2. This change puts scripting defines to ensure compilation isn't failing on older versions.

Height Task ID(s) (If applicable): N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
