### PR TITLE
`Refresh Media Sources` button behaviour in 360 Setup Window

### DIFF
--- a/Editor/Setup360Window.cs
+++ b/Editor/Setup360Window.cs
@@ -39,13 +39,9 @@ namespace Cognitive3D
             selectedClip = (UnityEngine.Video.VideoClip)EditorGUILayout.ObjectField("Video Clip", selectedClip, typeof(UnityEngine.Video.VideoClip), true);
             userCamera = (UnityEngine.Camera)EditorGUILayout.ObjectField("Main Camera", userCamera, typeof(UnityEngine.Camera), true);
 
-            if (EditorCore.MediaSources.Length == 0)
+            if (GUILayout.Button("Refresh Media Sources"))
             {
-                if (GUILayout.Button("Refresh Media Sources"))
-                {
-                    EditorCore.RefreshMediaSources();
-                }
-                return;
+                EditorCore.RefreshMediaSources();
             }
 
             //media source

--- a/Editor/Setup360Window.cs
+++ b/Editor/Setup360Window.cs
@@ -55,7 +55,10 @@ namespace Cognitive3D
             GUILayout.BeginHorizontal();
             GUILayout.Label("Description:", GUILayout.Width(100));
             EditorGUI.BeginDisabledGroup(true);
-            EditorGUILayout.TextArea(EditorCore.MediaSources[_choiceIndex].description);
+            if (EditorCore.MediaSources.Length > 0)
+            {
+                EditorGUILayout.TextArea(EditorCore.MediaSources[_choiceIndex].description);
+            }
             EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 


### PR DESCRIPTION
# Description

The "Refresh Media Sources" button on the `360 Setup` window could only be clicked once. However the `Refresh` button on the `Media Component` persists. This change updates the `360 Setup Window` to follow the same behaviour. 

The following GIFs showcase behaviour before and after the change.

### Before

![360Setup_Pre](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/c8b32abc-57c3-48da-874e-3483bf029a19)

### After

![360Setup_Post](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/68e39aa1-5b3d-41fd-b1f0-895e7678949f)


Height Task ID(s) (If applicable): https://c3d.height.app/T-4691

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
