### PR TITLE
Updating Profiler Sensor to 1Hz

### DIFF
--- a/Runtime/Components/ProfilerSensor.cs
+++ b/Runtime/Components/ProfilerSensor.cs
@@ -19,6 +19,9 @@ namespace Cognitive3D
         private readonly string MAIN_THREAD_TIME = "Main Thread";
         private readonly string DRAW_CALLS_COUNT = "Draw Calls Count";
 
+        readonly float ProfilerSensorRecordingInterval = 1.0f;
+        float currentTime = 0;
+
         private readonly float NANOSECOND_TO_MILLISECOND_MULTIPLIER = 1e-6f;
         private readonly float BYTES_TO_MEGABYTES_DIVIDER = 1024 * 1024;
 
@@ -36,29 +39,36 @@ namespace Cognitive3D
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-            // We don't want these lines to execute if component disabled
-            // Without this condition, these lines will execute regardless
-            //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()  
-            if (isActiveAndEnabled)
+            currentTime += deltaTime;
+
+            // Send data at 1Hz
+            if (currentTime > ProfilerSensorRecordingInterval)
             {
-                // number of draw calls as count
-                long drawCalls = drawCallsRecorder.LastValue;
+                currentTime = 0;
+                // We don't want these lines to execute if component disabled
+                // Without this condition, these lines will execute regardless
+                //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()  
+                if (isActiveAndEnabled)
+                {
+                    // number of draw calls as count
+                    long drawCalls = drawCallsRecorder.LastValue;
 
-                // memory usage in bytes, we are converting to MB
-                // casting to float to handle decimal places
-                float systemMemory = (float)systemMemoryRecorder.LastValue / BYTES_TO_MEGABYTES_DIVIDER;
+                    // memory usage in bytes, we are converting to MB
+                    // casting to float to handle decimal places
+                    float systemMemory = (float)systemMemoryRecorder.LastValue / BYTES_TO_MEGABYTES_DIVIDER;
 
-                // thread time in nanoseconds, we are converting to milliseconds
-                // casting to float to handle decimal places
-                float mainThreadTime = (float)mainThreadTimeRecorder.LastValue * NANOSECOND_TO_MILLISECOND_MULTIPLIER;
+                    // thread time in nanoseconds, we are converting to milliseconds
+                    // casting to float to handle decimal places
+                    float mainThreadTime = (float)mainThreadTimeRecorder.LastValue * NANOSECOND_TO_MILLISECOND_MULTIPLIER;
 
-                SensorRecorder.RecordDataPoint("c3d.profiler.drawCallsCount", drawCalls);
-                SensorRecorder.RecordDataPoint("c3d.profiler.systemMemoryInMB", systemMemory);
-                SensorRecorder.RecordDataPoint("c3d.profiler.mainThreadTimeInMs", mainThreadTime);
-            }
-            else
-            {
-                Debug.LogWarning("Profiler Sensor component is disabled. Please enable in inspector.");
+                    SensorRecorder.RecordDataPoint("c3d.profiler.drawCallsCount", drawCalls);
+                    SensorRecorder.RecordDataPoint("c3d.profiler.systemMemoryInMB", systemMemory);
+                    SensorRecorder.RecordDataPoint("c3d.profiler.mainThreadTimeInMs", mainThreadTime);
+                }
+                else
+                {
+                    Debug.LogWarning("Profiler Sensor component is disabled. Please enable in inspector.");
+                }
             }
         }
 


### PR DESCRIPTION
# Description

To prevent the SDK from sending too many frequent web requests, we are reducing the frequency of profiler sensor to 1Hz from default 10Hz.

Height Task ID(s) (If applicable): https://c3d.height.app/T-4779

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
