### PR TITLE
Fix for pool id selection as id source

### DIFF
--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -189,35 +189,33 @@ namespace Cognitive3D
                     var dyn = target as DynamicObject;
                     if (dyn.IdPool == null)
                     {
-                        if (GUILayout.Button("New Dynamic Object Id Pool")) //this can overwrite an existing id pool with the same name. should this just find a pool?
-                        {
-                            string poolMeshName = dyn.MeshName;
-                            string assetPath = "Assets/" + poolMeshName + " Id Pool.asset";
+                        //this can overwrite an existing id pool with the same name. should this just find a pool?
+                        string poolMeshName = dyn.MeshName;
+                        string assetPath = "Assets/" + poolMeshName + " Id Pool.asset";
 
-                            //check if asset exists
-                            var foundPool = (DynamicObjectIdPool)AssetDatabase.LoadAssetAtPath(assetPath, typeof(DynamicObjectIdPool));
-                            if (foundPool == null)
+                        //check if asset exists
+                        var foundPool = (DynamicObjectIdPool)AssetDatabase.LoadAssetAtPath(assetPath, typeof(DynamicObjectIdPool));
+                        if (foundPool == null)
+                        {
+                            var pool = GenerateNewIDPoolAsset(assetPath, dyn);
+                            idPool.objectReferenceValue = pool;
+                        }
+                        else
+                        {
+                            //popup - new pool asset, add to existing pool (if matching mesh name), cancel
+                            int result = EditorUtility.DisplayDialogComplex("Found Id Pool", "An existing Id Pool with the same mesh name was found. Do you want to use this Id Pool instead?", "New Asset", "Cancel", "Use Existing");
+
+                            if (result == 0)//new asset with unique name
                             {
-                                var pool = GenerateNewIDPoolAsset(assetPath, dyn);
+                                string finalAssetPath = UnityEditor.AssetDatabase.GenerateUniqueAssetPath(assetPath);
+                                var pool = GenerateNewIDPoolAsset(finalAssetPath, dyn);
                                 idPool.objectReferenceValue = pool;
                             }
-                            else
+                            if (result == 2) //reference existing pool
                             {
-                                //popup - new pool asset, add to existing pool (if matching mesh name), cancel
-                                int result = EditorUtility.DisplayDialogComplex("Found Id Pool", "An existing Id Pool with the same mesh name was found. Do you want to use this Id Pool instead?", "New Asset", "Cancel", "Use Existing");
-
-                                if (result == 0)//new asset with unique name
-                                {
-                                    string finalAssetPath = UnityEditor.AssetDatabase.GenerateUniqueAssetPath(assetPath);
-                                    var pool = GenerateNewIDPoolAsset(finalAssetPath, dyn);
-                                    idPool.objectReferenceValue = pool;
-                                }
-                                if (result == 2) //reference existing pool
-                                {
-                                    idPool.objectReferenceValue = foundPool;
-                                }
-                                if (result == 1) { }//cancel
+                                idPool.objectReferenceValue = foundPool;
                             }
+                            if (result == 1) { }//cancel
                         }
                     }
                 }


### PR DESCRIPTION
# Description

The code previously verified the pressing of a button that did not exist, causing an obstruction in creating a new pool or utilizing an existing one.

- if statement has been removed

Height Task ID(s) (If applicable): https://c3d.height.app/T-4869

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
