### PR TITLE
Remove PartySize from OculusSocial component

### DIFF
--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -19,11 +19,8 @@ namespace Cognitive3D.Components
         [Tooltip("Used to automatically set user's display name as participant name on the dashboard")]
         [SerializeField]
         private bool AssignOculusNameToParticipantName = false;
-
-        [Tooltip("Sets a session property with the size of the user's party (skipped if playing alone)")]
-        [SerializeField]
-        private bool RecordPartySize = true;
 #endif
+
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
@@ -45,10 +42,6 @@ namespace Cognitive3D.Components
             if (Core.IsInitialized())
             {
                 Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
-                if (RecordPartySize)
-                {
-                    CheckPartySize();
-                }
             }
 
             if (!string.IsNullOrEmpty(appID))
@@ -147,45 +140,13 @@ namespace Cognitive3D.Components
 #endif
 
         /// <summary>
-        /// Checks the number of people in the room/party
-        /// </summary>
-        void CheckPartySize()
-        {
-#if C3D_OCULUS
-            Oculus.Platform.Parties.GetCurrent().OnComplete(delegate (Oculus.Platform.Message<Oculus.Platform.Models.Party> message)
-            {
-                if (message.IsError)
-                {
-                    Util.logDebug(message.GetError().Message);
-                }
-                else if (message.Data != null)
-                {
-                    if (message.Data.UsersOptional != null)
-                    {
-#if XRPF
-                        if (XRPF.PrivacyFramework.Agreement.IsAgreementComplete && XRPF.PrivacyFramework.Agreement.IsSocialDataAllowed)
-#endif
-                        {
-                            Cognitive3D_Manager.SetSessionProperty("Party Size", message.Data.UsersOptional.Count);
-                        }
-                    }
-                }
-                else
-                {
-                    //no party
-                }
-            });
-#endif
-        }
-
-        /// <summary>
         /// Description to display in inspector
         /// </summary>
         /// <returns> A string representing the description </returns>
         public override string GetDescription()
         {
 #if C3D_OCULUS
-            return "Set a property for the user's ID, name, and party size.";
+            return "Set a property for the user's oculus id and display name";
 #else
             return "Oculus Social properties can only be accessed when using the Oculus Platform";
 #endif


### PR DESCRIPTION
# Description

Removed Party Size from Oculus Social because it wasn't being used

Height Task ID(s) (If applicable): https://c3d.height.app/T-4897
## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
