### PR TITLE
Fix for Dynamic `ID Source` Selection

### DIFF
--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -60,12 +60,9 @@ namespace Cognitive3D
             var positionThreshold = serializedObject.FindProperty("PositionThreshold");
             var rotationThreshold = serializedObject.FindProperty("RotationThreshold");
             var scaleThreshold = serializedObject.FindProperty("ScaleThreshold");
-            //var useCustomId = serializedObject.FindProperty("UseCustomId");
             var customId = serializedObject.FindProperty("CustomId");
             var idSource = serializedObject.FindProperty("idSource");
-            //var commonMeshName = serializedObject.FindProperty("CommonMesh");
             var meshname = serializedObject.FindProperty("MeshName");
-            //var useCustomMesh = serializedObject.FindProperty("UseCustomMesh");
             var isController = serializedObject.FindProperty("IsController");
             var syncWithGaze = serializedObject.FindProperty("SyncWithPlayerGazeTick");
             var idPool = serializedObject.FindProperty("IdPool");

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -125,28 +125,15 @@ namespace Cognitive3D
 
             //dynamic id sources - custom id, generate at runtime, id pool asset
             var primaryDynamic = targets[0] as DynamicObject;
-            if (primaryDynamic.UseCustomId)
-            {
-                targetIdType = 0;
-                idType = 0;
-            }
-            else if (primaryDynamic.IdPool != null)
-            {
-                targetIdType = 2;
-                idType = 2;
-            }
-            else
-            {
-                targetIdType = 1;
-                idType = 1;
-            }
+            idType = (int) primaryDynamic.idSource;
+            targetIdType = (int) primaryDynamic.idSource;
 
             //check if all selected objects have the same idtype
             foreach (var t in targets)
             {
                 var tdyn = (DynamicObject)t;
-                if (tdyn.UseCustomId) { if (targetIdType != 0) { allSelectedShareIdType = false; break; } }
-                else if (tdyn.IdPool != null) {if (targetIdType != 2) { allSelectedShareIdType = false; break; } }
+                if (tdyn.idSource == DynamicObject.IdSourceType.CustomID) { if (targetIdType != 0) { allSelectedShareIdType = false; break; } }
+                else if (tdyn.idSource == DynamicObject.IdSourceType.PoolID) {if (targetIdType != 2) { allSelectedShareIdType = false; break; } }
                 else if (targetIdType != 1) { allSelectedShareIdType = false; break; }
             }
 
@@ -160,6 +147,7 @@ namespace Cognitive3D
             {
                 GUILayout.BeginHorizontal();
                 idType = EditorGUILayout.Popup(new GUIContent("Id Source"), idType, idTypeNames);
+                primaryDynamic.idSource = (DynamicObject.IdSourceType) idType;
 
                 if (idType == 0) //custom id
                 {

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -159,7 +159,6 @@ namespace Cognitive3D
                 if (idType == 0) //custom id
                 {
                     EditorGUILayout.PropertyField(customId, new GUIContent(""));
-                    useCustomId.boolValue = true;
                     idPool.objectReferenceValue = null;
                 }
                 else if (idType == 1) //generate id
@@ -168,14 +167,12 @@ namespace Cognitive3D
                     EditorGUILayout.LabelField(new GUIContent("Id will be generated at runtime", "This object will not be included in aggregation metrics on the dashboard"));
                     EditorGUI.EndDisabledGroup();
                     customId.stringValue = string.Empty;
-                    useCustomId.boolValue = false;
                     idPool.objectReferenceValue = null;
                 }
                 else if (idType == 2) //id pool
                 {
                     EditorGUILayout.ObjectField(idPool, new GUIContent("", "Provides a consistent list of Ids to be used at runtime. Allows aggregated data from objects spawned at runtime"));
                     customId.stringValue = string.Empty;
-                    useCustomId.boolValue = false;
                 }
                 GUILayout.EndHorizontal();
 

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -143,15 +143,13 @@ namespace Cognitive3D
             else
             {
                 GUILayout.BeginHorizontal();
-                idType = EditorGUILayout.Popup(new GUIContent("Id Source"), idType, idTypeNames);
-                primaryDynamic.idSource = (DynamicObject.IdSourceType) idType;
-
-                if (idType == 0) //custom id
+                primaryDynamic.idSource = (DynamicObject.IdSourceType) EditorGUILayout.Popup(new GUIContent("Id Source"), idType, idTypeNames);
+                if (primaryDynamic.idSource == DynamicObject.IdSourceType.CustomID) //custom id
                 {
                     EditorGUILayout.PropertyField(customId, new GUIContent(""));
                     idPool.objectReferenceValue = null;
                 }
-                else if (idType == 1) //generate id
+                else if (primaryDynamic.idSource == DynamicObject.IdSourceType.GeneratedID) //generate id
                 {
                     EditorGUI.BeginDisabledGroup(true);
                     EditorGUILayout.LabelField(new GUIContent("Id will be generated at runtime", "This object will not be included in aggregation metrics on the dashboard"));
@@ -159,14 +157,14 @@ namespace Cognitive3D
                     customId.stringValue = string.Empty;
                     idPool.objectReferenceValue = null;
                 }
-                else if (idType == 2) //id pool
+                else if (primaryDynamic.idSource == DynamicObject.IdSourceType.PoolID) //id pool
                 {
                     EditorGUILayout.ObjectField(idPool, new GUIContent("", "Provides a consistent list of Ids to be used at runtime. Allows aggregated data from objects spawned at runtime"));
                     customId.stringValue = string.Empty;
                 }
                 GUILayout.EndHorizontal();
 
-                if (idType == 2) //id pool
+                if (primaryDynamic.idSource == DynamicObject.IdSourceType.PoolID) //id pool
                 {
                     var dyn = target as DynamicObject;
                     if (dyn.IdPool == null)
@@ -217,7 +215,6 @@ namespace Cognitive3D
                     else if (tdyn.idSource == DynamicObject.IdSourceType.PoolID) { if (targetIdType != 2) { allSelectedShareIdType = false; break; } }
                     else if (targetIdType != 1) { allSelectedShareIdType = false; break; }
                 }
-
             }
 
             basicGUIChanged = EditorGUI.EndChangeCheck();

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -132,17 +132,6 @@ namespace Cognitive3D
 
             //dynamic id sources - custom id, generate at runtime, id pool asset
             var primaryDynamic = targets[0] as DynamicObject;
-            idType = (int) primaryDynamic.idSource;
-            targetIdType = (int) primaryDynamic.idSource;
-
-            //check if all selected objects have the same idtype
-            foreach (var t in targets)
-            {
-                var tdyn = (DynamicObject)t;
-                if (tdyn.idSource == DynamicObject.IdSourceType.CustomID) { if (targetIdType != 0) { allSelectedShareIdType = false; break; } }
-                else if (tdyn.idSource == DynamicObject.IdSourceType.PoolID) {if (targetIdType != 2) { allSelectedShareIdType = false; break; } }
-                else if (targetIdType != 1) { allSelectedShareIdType = false; break; }
-            }
 
             //if all id sources from selected objects are the same, display shared property fields
             //otherwise display 'multiple values'
@@ -213,6 +202,21 @@ namespace Cognitive3D
                         }
                     }
                 }
+
+                // Support for multi-select
+                idType = (int)primaryDynamic.idSource;
+                targetIdType = (int)primaryDynamic.idSource;
+
+                // check if all selected objects have the same id type
+                // match each idSource with the targetIdType of the first guy
+                foreach (var t in targets)
+                {
+                    var tdyn = (DynamicObject)t;
+                    if (tdyn.idSource == DynamicObject.IdSourceType.CustomID) { if (targetIdType != 0) { allSelectedShareIdType = false; break; } }
+                    else if (tdyn.idSource == DynamicObject.IdSourceType.PoolID) { if (targetIdType != 2) { allSelectedShareIdType = false; break; } }
+                    else if (targetIdType != 1) { allSelectedShareIdType = false; break; }
+                }
+
             }
 
             basicGUIChanged = EditorGUI.EndChangeCheck();

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -34,7 +34,8 @@ namespace Cognitive3D
             PrefabUtility.prefabInstanceUpdated -= PrefabInstanceUpdated;
         }
 
-        int idType = -1;
+        // Default is CustomID
+        int idType = 0;
 
         /// <summary>
         /// Must follow this order:

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -35,6 +35,13 @@ namespace Cognitive3D
         }
 
         int idType = -1;
+
+        /// <summary>
+        /// Must follow this order:
+        ///     CustomID = 0
+        ///     GeneratedID = 1
+        ///     PoolID = 2
+        /// </summary>
         GUIContent[] idTypeNames = new GUIContent[] {
             new GUIContent("Custom Id", "For objects that start in the scene"),
             new GUIContent("Generate Id", "For spawned objects that DO NOT need aggregate data"),
@@ -69,7 +76,7 @@ namespace Cognitive3D
                 var dynamic = t as DynamicObject;
                 if (dynamic.editorInstanceId != dynamic.GetInstanceID() || string.IsNullOrEmpty(dynamic.CustomId)) //only check if something has changed on a dynamic, or if the id is empty
                 {
-                    if (dynamic.UseCustomId && idType == 0)
+                    if ((dynamic.idSource == DynamicObject.IdSourceType.CustomID) && idType == 0)
                     {
                         if (string.IsNullOrEmpty(AssetDatabase.GetAssetPath(dynamic.gameObject)))//scene asset
                         {
@@ -320,7 +327,7 @@ namespace Cognitive3D
         void UploadCustomIdForAggregation()
         {
             var dyn = target as DynamicObject;
-            if (dyn.UseCustomId)
+            if (dyn.idSource == DynamicObject.IdSourceType.CustomID)
             {
                 Debug.Log("Cognitive3D Dynamic Object: upload custom id to scene");
                 EditorCore.RefreshSceneVersion(delegate ()
@@ -371,7 +378,7 @@ namespace Cognitive3D
 
             for (int i = dynamics.Length - 1; i >= 0; i--) //loop backwards to adjust newest dynamics instead of oldest
             {
-                if (!dynamics[i].UseCustomId) { continue; }
+                if (dynamics[i].idSource != DynamicObject.IdSourceType.CustomID) { continue; }
 
                 if (usedids.Contains(dynamics[i].CustomId) || string.IsNullOrEmpty(dynamics[i].CustomId))
                 {

--- a/Editor/DynamicObjectsWindow.cs
+++ b/Editor/DynamicObjectsWindow.cs
@@ -211,7 +211,7 @@ namespace Cognitive3D
                     bool selected = selectedDynamicsOnFocus.Contains(o);
                     var found = dashboardObjects.Find(delegate (DashboardObject obj)
                         {
-                            if (!o.UseCustomId) { return false; }
+                            if (o.idSource != DynamicObject.IdSourceType.CustomID) { return false; }
                             return obj.sdkId == o.GetId();
                         });
                     bool uploaded = found != null;
@@ -674,7 +674,7 @@ namespace Cognitive3D
                     Entry found = Entries.Find(delegate (Entry obj)
                     {
                         if (obj.objectReference == null) { return false; }
-                        if (!obj.objectReference.UseCustomId) { return false; }
+                        if (obj.objectReference.idSource != DynamicObject.IdSourceType.CustomID) { return false; }
                         return obj.objectReference.GetId() == dashboardObject.sdkId;
                     });
                     if (found == null) { continue; }
@@ -1007,7 +1007,7 @@ namespace Cognitive3D
             {
                 GUI.Label(idRect, "ID Pool (" + dynamic.idPoolCount + ")", dynamiclabel);
             }
-            else if (dynamic.objectReference.UseCustomId)
+            else if (dynamic.objectReference.idSource == DynamicObject.IdSourceType.CustomID)
             {
                 GUI.Label(idRect, new GUIContent(dynamic.objectReference.GetId(), dynamic.objectReference.GetId()), dynamiclabel);
             }
@@ -1041,12 +1041,12 @@ namespace Cognitive3D
                 GUI.Label(uploaded, new GUIContent(EditorCore.CircleEmpty, "IDs in this pool have not been uploaded to dashboard"), image_centered);
                 //TODO check if any/all ids have been uploaded from id pool asset
             }
-            else if (dynamic.objectReference.IdPool != null)
+            else if (dynamic.objectReference.idSource == DynamicObject.IdSourceType.PoolID)
             {
                 //dynamic with id pool reference
                 GUI.Label(uploaded, new GUIContent("", "Objects using an ID pool. Check that the Pool asset IDs have been uploaded to aggregate these objects"), image_centered);
             }
-            else if (dynamic.objectReference.UseCustomId == false)
+            else if (dynamic.objectReference.idSource == DynamicObject.IdSourceType.GeneratedID)
             {
                 //generated at runtime
                 GUI.Label(uploaded, new GUIContent("", "Objects with generated IDs are not aggregated between sessions"), image_centered);
@@ -1243,7 +1243,7 @@ namespace Cognitive3D
 
                             if (!entry.isIdPool)
                             {
-                                if (dyn.UseCustomId == true)
+                                if (dyn.idSource == DynamicObject.IdSourceType.CustomID)
                                 {
                                     manifestList.Add(entry.objectReference);
                                 }

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -18,6 +18,16 @@ namespace Cognitive3D
     [HelpURL("https://docs.cognitive3d.com/unity/dynamic-objects/")]
     public class DynamicObject : MonoBehaviour
     {
+        
+        public enum IdSourceType
+        {
+            CustomID = 0,
+            GeneratedID = 1,
+            PoolID = 2
+        }
+
+        public IdSourceType idSource = IdSourceType.CustomID;
+        
         //developer facing high level controller type selection
         public enum ControllerType
         {

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -18,7 +18,13 @@ namespace Cognitive3D
     [HelpURL("https://docs.cognitive3d.com/unity/dynamic-objects/")]
     public class DynamicObject : MonoBehaviour
     {
-        
+        /// <summary>
+        /// To know the "ID Source Type" set from inspector
+        /// Must follow this order:
+        ///     CustomID = 0
+        ///     GeneratedID = 1
+        ///     PoolID = 2
+        /// </summary>
         public enum IdSourceType
         {
             CustomID = 0,
@@ -26,6 +32,7 @@ namespace Cognitive3D
             PoolID = 2
         }
 
+        // Default idSource
         public IdSourceType idSource = IdSourceType.CustomID;
         
         //developer facing high level controller type selection
@@ -122,9 +129,6 @@ namespace Cognitive3D
 
         //data id is the general way to get the actual id from the dynamic object (generated or custom id). use GetId
         private string DataId;
-        //this is only used for a custom editor to help CustomId be set correctly
-        [SerializeField]
-        internal bool UseCustomId = true;
 
         //custom id is set in editor and will be used when set. internal to be accessed by various editor windows
         /// <summary>
@@ -218,11 +222,10 @@ namespace Cognitive3D
                 UpdateRate = 64;
             }
 
-            string registerid = UseCustomId ? CustomId : "";
+            string registerid = (idSource == IdSourceType.CustomID) ? CustomId : "";
 
-            if (!UseCustomId && IdPool != null)
+            if (idSource == IdSourceType.GeneratedID)
             {
-                UseCustomId = true;
                 CustomId = IdPool.GetId();
                 registerid = CustomId;
             }
@@ -387,7 +390,7 @@ namespace Cognitive3D
             OnDisable();
 
             //update displayed customid
-            this.UseCustomId = true;
+            this.idSource = IdSourceType.CustomID;
             this.CustomId = customId;
 
             //register new dynamic data with dynamic manager
@@ -422,7 +425,7 @@ namespace Cognitive3D
             OnDisable();
 
             //update displayed customid
-            this.UseCustomId = true;
+            this.idSource = IdSourceType.CustomID;
             this.CustomId = customId;
             this.MeshName = meshName;
 


### PR DESCRIPTION
# Description

In Unity SDK - user wasn't able to select `Pool ID` as an option for ID Source for Dynamic Objects. This PR fixes that issue.

## Before:
![DynamicPoolBug](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/d6af614a-5cf8-42c7-a096-30781ea13553)

## After
https://www.loom.com/share/1c6aebb55c19443a97f73f30b71258e6?sid=7e14b649-3450-4fb3-9f07-e84f9a441e1b

Height Task ID(s) (If applicable): https://c3d.height.app/T-4869

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
