### PR TITLE
Include Child Meshes with CustomRenderExporter Script

### DIFF
--- a/Editor/ExportUtility.cs
+++ b/Editor/ExportUtility.cs
@@ -618,33 +618,34 @@ namespace Cognitive3D
                 EditorUtility.DisplayProgressBar("Export GLTF", "Bake Custom Render Exporters " + currentTask + "/" + CustomRenders.Length, currentProgress);
 
                 if (!customRender.gameObject.activeInHierarchy) { continue; }
-                var data = customRender.RenderMeshCustom();
-                if (data == null) { continue; }
+                var AllData = customRender.RenderMeshCustom();
+                if (AllData == null) { continue; }
 
-                BakeableMesh bm = new BakeableMesh();
-                bm.tempGo = new GameObject(data.name + "BAKEABLE MESH");
-                bm.tempGo.transform.parent = data.transform;
-                bm.tempGo.transform.localRotation = Quaternion.identity;
-                bm.tempGo.transform.localPosition = Vector3.zero;
-                bm.tempGo.transform.localScale = Vector3.one;
+                foreach (var data in AllData)
+                {
+                    BakeableMesh bm = new BakeableMesh();
+                    bm.tempGo = new GameObject(data.name + "BAKEABLE MESH");
+                    bm.tempGo.transform.parent = data.transform;
+                    bm.tempGo.transform.localRotation = Quaternion.identity;
+                    bm.tempGo.transform.localPosition = Vector3.zero;
+                    bm.tempGo.transform.localScale = Vector3.one;
 
-                bm.meshRenderer = bm.tempGo.AddComponent<MeshRenderer>();
-                bm.meshRenderer.sharedMaterial = data.material;
-                bm.meshFilter = bm.tempGo.AddComponent<MeshFilter>();
+                    bm.meshRenderer = bm.tempGo.AddComponent<MeshRenderer>();
+                    bm.meshRenderer.sharedMaterial = data.material;
+                    bm.meshFilter = bm.tempGo.AddComponent<MeshFilter>();
 
-                bm.meshFilter.sharedMesh = data.meshdata;
-                meshes.Add(bm);
-                //ProceduralMeshFilters.Add(bm.meshFilter);
-                ProceduralMeshFilters.Add(data.tempGameObject.GetComponent<MeshFilter>());
-                deleteCustomRenders.Add(data.tempGameObject);
+                    bm.meshFilter.sharedMesh = data.meshdata;
+                    meshes.Add(bm);
+                    ProceduralMeshFilters.Add(data.tempGameObject.GetComponent<MeshFilter>());
+                    deleteCustomRenders.Add(data.tempGameObject);
 
-                string finalPath = UnityGLTF.GLTFSceneExporter.ConstructImageFilenamePath((Texture2D)data.material.mainTexture, UnityGLTF.GLTFSceneExporter.TextureMapType.Main, path);
+                    string finalPath = UnityGLTF.GLTFSceneExporter.ConstructImageFilenamePath((Texture2D)data.material.mainTexture, UnityGLTF.GLTFSceneExporter.TextureMapType.Main, path);
+                    //put together a list of textures to be skipped based on path
+                    customTextureExports.Add(finalPath);
 
-                //put together a list of textures to be skipped based on path
-                customTextureExports.Add(finalPath);
-
-                //save out the texture here, instead of keeping it in memory
-                System.IO.File.WriteAllBytes(finalPath, ((Texture2D)data.material.mainTexture).EncodeToPNG());
+                    //save out the texture here, instead of keeping it in memory
+                    System.IO.File.WriteAllBytes(finalPath, ((Texture2D)data.material.mainTexture).EncodeToPNG());
+                }
             }
 
             currentTask = 0;

--- a/Editor/GLTF/GLTFSceneExporter.cs
+++ b/Editor/GLTF/GLTFSceneExporter.cs
@@ -596,7 +596,7 @@ namespace Cognitive3D.UnityGLTF
 		{
 			var imagePath = UnityEditor.AssetDatabase.GetAssetPath(texture);
 			string filenamePath;
-			if (texture.name != Uri.EscapeUriString(texture.name).Replace('#', '_'))
+			if (texture.name != Uri.EscapeUriString(texture.name).Replace('#', '_').Replace(':', '_'))
 			{
 				string texturenamehash = Mathf.Abs(texture.name.GetHashCode()).ToString();
 				filenamePath = outputPath + "/" + Mathf.Abs(imagePath.GetHashCode()) + texturenamehash + textureMapType;


### PR DESCRIPTION
# Description

Changed CustomRenderExporter component to include exporting child meshes. Also added:
* URP support (must be set per component in the scene)
* Basic lod support (highest resolution only)
* Option to bake textures from topdown only, decreasing export time
* Fixed filename escaping with ':'

Height Task ID(s) (If applicable): T-4981

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned and notified Reviewers for this PR
