### PR TITLE
Fix for incorrect reference of IdPool for Generated ID

### DIFF
--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -224,7 +224,7 @@ namespace Cognitive3D
 
             string registerid = (idSource == IdSourceType.CustomID) ? CustomId : "";
 
-            if (idSource == IdSourceType.GeneratedID)
+            if (idSource == IdSourceType.PoolID && IdPool != null)
             {
                 CustomId = IdPool.GetId();
                 registerid = CustomId;


### PR DESCRIPTION
# Description

- Seems like it was an error in translating logic to enums during refactoring
- Changed source ID type in if statement to PoolID (line 227)

Height Task ID(s) (If applicable): https://c3d.height.app/T-5075

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have assigned and notified Reviewers for this PR
