### PR TITLE
Progressive wait times for retries on 500 responses and introduced delays for cache data web requests

### DIFF
--- a/Runtime/Internal/NetworkManager.cs
+++ b/Runtime/Internal/NetworkManager.cs
@@ -227,7 +227,7 @@ namespace Cognitive3D
                 CacheRequest.Dispose();
                 CacheRequest = null;
                 CacheResponseAction = null;
-                if(runtimeCache != null)
+                if (runtimeCache != null)
                 {
                     runtimeCache.PopContent();
                 }
@@ -301,7 +301,7 @@ namespace Cognitive3D
 
             string url = "";
             string content = "";
-            if(runtimeCache != null)
+            if (runtimeCache != null)
             {
                 if (runtimeCache.PeekContent(ref url, ref content))
                 {
@@ -422,9 +422,9 @@ namespace Cognitive3D
         internal async void Post(string url, string stringcontent)
         {
             // Cooldown procedure
-            if(lastRequestFailed)
+            if (lastRequestFailed)
             {
-                if(Time.time < currentDelay + clockTime)
+                if (Time.time < currentDelay + clockTime)
                 {
                     WriteToCache(url, stringcontent);
                     return;
@@ -448,7 +448,7 @@ namespace Cognitive3D
 
             // Triggering cooldown process when the response code is either 500 or 0
             // Response code 0 indicates a disconnection from the internet
-            if(lastResponseCode >= 500 || lastResponseCode == 0)
+            if (lastResponseCode >= 500 || lastResponseCode == 0)
             {
                 Debug.LogWarning("Response Code is " + lastResponseCode + ". Initiating cooldown procedure.");
                 clockTime = Time.time;
@@ -467,7 +467,7 @@ namespace Cognitive3D
         // Writing to cache
         private void WriteToCache(string url, string content)
         {            
-            if(runtimeCache.CanWrite(url, content))
+            if (runtimeCache.CanWrite(url, content))
             {
                 runtimeCache.WriteContent(url, content);
             }
@@ -477,7 +477,7 @@ namespace Cognitive3D
         // Exponential backoff strategy: Increase delay exponentially
         private float GetExponentialBackoff(float retryDelay)
         {
-            if(retryDelay < maxRetryDelay)
+            if (retryDelay < maxRetryDelay)
             {
                 return retryDelay * 2;
             }

--- a/Runtime/Internal/NetworkManager.cs
+++ b/Runtime/Internal/NetworkManager.cs
@@ -230,7 +230,10 @@ namespace Cognitive3D
                 CacheRequest.Dispose();
                 CacheRequest = null;
                 CacheResponseAction = null;
-                runtimeCache.PopContent();
+                if(runtimeCache != null)
+                {
+                    runtimeCache.PopContent();
+                }
                 isuploadingfromcache = false;
                 LoopUploadFromLocalCache();
             }
@@ -297,32 +300,35 @@ namespace Cognitive3D
 
             string url = "";
             string content = "";
-            if (runtimeCache.PeekContent(ref url, ref content))
+            if(runtimeCache != null)
             {
-                isuploadingfromcache = true;
-                //lc.GetCachedDataPoint(out url, out content);
-                
-                //wait for post response
-                var bytes = System.Text.UTF8Encoding.UTF8.GetBytes(content);
-                CacheRequest = UnityWebRequest.Put(url, bytes);
-                CacheRequest.method = "POST";
-                CacheRequest.SetRequestHeader("Content-Type", "application/json");
-                CacheRequest.SetRequestHeader("X-HTTP-Method-Override", "POST");
-                CacheRequest.SetRequestHeader("Authorization", CognitiveStatics.ApplicationKey);
-                CacheRequest.SendWebRequest();
+                if (runtimeCache.PeekContent(ref url, ref content))
+                {
+                    isuploadingfromcache = true;
+                    //lc.GetCachedDataPoint(out url, out content);
+                    
+                    //wait for post response
+                    var bytes = System.Text.UTF8Encoding.UTF8.GetBytes(content);
+                    CacheRequest = UnityWebRequest.Put(url, bytes);
+                    CacheRequest.method = "POST";
+                    CacheRequest.SetRequestHeader("Content-Type", "application/json");
+                    CacheRequest.SetRequestHeader("X-HTTP-Method-Override", "POST");
+                    CacheRequest.SetRequestHeader("Authorization", CognitiveStatics.ApplicationKey);
+                    CacheRequest.SendWebRequest();
 
-                if (Cognitive3D_Preferences.Instance.EnableDevLogging)
-                    Util.logDevelopment("NETWORK LoopUploadFromLocalCache " + url + " " + content);
+                    if (Cognitive3D_Preferences.Instance.EnableDevLogging)
+                        Util.logDevelopment("NETWORK LoopUploadFromLocalCache " + url + " " + content);
 
-                CacheResponseAction = instance.CACHEDResponseCallback;
+                    CacheResponseAction = instance.CACHEDResponseCallback;
 
-                instance.StartCoroutine(instance.WaitForFullResponse(CacheRequest, content, CacheResponseAction, false));
-            }
-            else if (!runtimeCache.HasContent())
-            {
-                if (cacheCompletedAction != null)
-                    cacheCompletedAction.Invoke();
-                cacheCompletedAction = null;
+                    instance.StartCoroutine(instance.WaitForFullResponse(CacheRequest, content, CacheResponseAction, false));
+                }
+                else if (!runtimeCache.HasContent())
+                {
+                    if (cacheCompletedAction != null)
+                        cacheCompletedAction.Invoke();
+                    cacheCompletedAction = null;
+                }
             }
         }
         

--- a/Runtime/Internal/NetworkManager.cs
+++ b/Runtime/Internal/NetworkManager.cs
@@ -224,9 +224,6 @@ namespace Cognitive3D
 
             if (responsecode == 200)
             {  
-                // A delay before sending a web request
-                await Task.Delay((int)cacheUploadInterval * 1000);
-
                 CacheRequest.Dispose();
                 CacheRequest = null;
                 CacheResponseAction = null;
@@ -235,6 +232,10 @@ namespace Cognitive3D
                     runtimeCache.PopContent();
                 }
                 isuploadingfromcache = false;
+
+                // A delay before sending a web request
+                await Task.Delay((int)cacheUploadInterval * 1000);
+
                 LoopUploadFromLocalCache();
             }
             else


### PR DESCRIPTION
# Description

Changed NetworkManager to include delays for 500 response retries and emptying cache:

- Added 2 seconds delay when uploading local cache data once connectivity is returned (Changed CACHEDResponseCallback() to an asynchronous function)
- Added progressive wait times when response codes are 500 or 0 (when WIFI is off)
- Resetting the progressive wait time to 1 minute once response code is 200 (Min wait time: 1 minute, Max wait time: 4 minutes)

Height Task ID(s) (If applicable): https://c3d.height.app/T-5070 , https://c3d.height.app/T-5030

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
