### PR TITLE
Updating ControllerTracking to prevent multiple repeated events; adding angle and height as a event property

### DIFF
--- a/Runtime/Components/ControllerTracking.cs
+++ b/Runtime/Components/ControllerTracking.cs
@@ -113,18 +113,25 @@ namespace Cognitive3D.Components
             //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()  
             if (isActiveAndEnabled)
             {
+                currentTime += deltaTime;
                 UpdateCooldownClock(deltaTime);
-
                 Transform rightControllerTransform;
                 Transform leftControllerTransform;
                 bool wasRightControllerFound = GameplayReferences.GetControllerTransform(false, out leftControllerTransform);
                 bool wasLeftControllerFound = GameplayReferences.GetControllerTransform(true, out rightControllerTransform);
-                leftControllerToHMD = leftControllerTransform.position - GameplayReferences.HMD.position;
-                rightControllerToHMD = rightControllerTransform.position - GameplayReferences.HMD.position;
-                leftAngle = Vector3.Angle(leftControllerToHMD, GameplayReferences.HMD.forward);
-                rightAngle = Vector3.Angle(rightControllerToHMD, GameplayReferences.HMD.forward);
+                
+                if (wasLeftControllerFound)
+                {
+                    leftControllerToHMD = leftControllerTransform.position - GameplayReferences.HMD.position;
+                    leftAngle = Vector3.Angle(leftControllerToHMD, GameplayReferences.HMD.forward);
+                }
 
-                currentTime += deltaTime;
+                if (wasRightControllerFound)
+                {
+                    rightControllerToHMD = rightControllerTransform.position - GameplayReferences.HMD.position;
+                    rightAngle = Vector3.Angle(rightControllerToHMD, GameplayReferences.HMD.forward);
+                }
+
                 if (currentTime > ControllerTrackingInterval)
                 {
                     if (wasLeftControllerFound)

--- a/Runtime/Components/ControllerTracking.cs
+++ b/Runtime/Components/ControllerTracking.cs
@@ -8,8 +8,51 @@ namespace Cognitive3D.Components
     public class ControllerTracking : AnalyticsComponentBase
     {
         private readonly float ControllerTrackingInterval = 1;
-        //counts up the deltatime to determine when the interval ends
+
+        /// <summary>
+        /// Counts up the deltatime to determine when the interval ends
+        /// </summary>
         private float currentTime;
+
+        /// <summary>
+        /// Angle between left controller and hmd; used as a property for custom event
+        /// </summary>
+        float leftAngle;
+
+        /// <summary>
+        /// Angle between right controller and hmd; used as a property for custom event
+        /// </summary>
+        float rightAngle;
+
+        /// <summary>
+        /// How long to wait before sending "left controller tracking lost" events
+        /// </summary>
+        private const float LEFT_TRACKING_COOLDOWN_TIME_IN_SECONDS = 5;
+
+        /// <summary>
+        /// How long to wait before sending "right controller tracking lost" events
+        /// </summary>
+        private const float RIGHT_TRACKING_COOLDOWN_TIME_IN_SECONDS = 5;
+
+        /// <summary>
+        /// Whether right controller tracking is in cooldown
+        /// </summary>
+        bool inRightCooldown;
+
+        /// <summary>
+        /// Whether right controller tracking is in cooldown
+        /// </summary>
+        bool inLeftCooldown;
+
+        /// <summary>
+        /// Internal clock to measure how long has elapsed since last left controller lost tracking event
+        /// </summary>
+        float leftCooldownTimer;
+
+        /// <summary>
+        /// Internal clock to measure how long has elapsed since last right controller lost tracking event
+        /// </summary>
+        float rightCooldownTimer;
 
         protected override void OnSessionBegin()
         {
@@ -24,24 +67,45 @@ namespace Cognitive3D.Components
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnPreSessionEnd += Cleanup;
         }
-
+        
+        /// <summary>
+        /// Fucntion to execute when xrNodeState.nodeType loses tracking
+        /// We have a cooldown timer to prevent multiple back-to-back events from being sent
+        /// </summary>
+        /// <param name="xrNodeState">The state of the device</param>
         public void OnTrackingLost(XRNodeState xrNodeState)
         {
-            if (!xrNodeState.tracked)
+            if (xrNodeState.nodeType == XRNode.RightHand && !inRightCooldown)
             {
-                if (xrNodeState.nodeType == XRNode.RightHand)
-                {
-                    new CustomEvent("c3d.Right Controller Lost tracking").Send();
-                }
-                if (xrNodeState.nodeType == XRNode.LeftHand)
-                {
-                    new CustomEvent("c3d.Left Controller Lost tracking").Send();
-                }
+                new CustomEvent("c3d.Right Controller Lost tracking")
+                    .SetProperty("Angle from HMD", rightAngle)
+                    .Send();
+                inRightCooldown = true;
+                rightCooldownTimer = 0;
+            }
+            if (xrNodeState.nodeType == XRNode.LeftHand && !inLeftCooldown)
+            {
+                new CustomEvent("c3d.Left Controller Lost tracking")
+                    .SetProperty("Angle from HMD", leftAngle)
+                    .Send();
+                inLeftCooldown = true;
+                leftCooldownTimer = 0;
             }
         }
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
+            UpdateCooldownClock(deltaTime);
+
+            Transform rightControllerTransform;
+            Transform leftControllerTransform;
+            bool wasRightControllerFound = GameplayReferences.GetControllerTransform(false, out leftControllerTransform);
+            bool wasLeftControllerFound = GameplayReferences.GetControllerTransform(true, out rightControllerTransform);
+            Vector3 leftControllerToHMD = leftControllerTransform.position - GameplayReferences.HMD.position;
+            Vector3 rightControllerToHMD = rightControllerTransform.position - GameplayReferences.HMD.position;
+            leftAngle = Vector3.Angle(leftControllerToHMD, GameplayReferences.HMD.forward);
+            rightAngle = Vector3.Angle(rightControllerToHMD, GameplayReferences.HMD.forward);
+
             // We don't want these lines to execute if component disabled
             // Without this condition, these lines will execute regardless
             //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()  
@@ -50,7 +114,16 @@ namespace Cognitive3D.Components
                 currentTime += deltaTime;
                 if (currentTime > ControllerTrackingInterval)
                 {
-                    ControllerTrackingIntervalEnd();
+                    if (wasLeftControllerFound)
+                    {
+                        SensorRecorder.RecordDataPoint("c3d.controller.left.height.fromHMD", leftControllerToHMD.y);
+                    }
+
+                    if (wasRightControllerFound)
+                    {
+                        SensorRecorder.RecordDataPoint("c3d.controller.right.height.fromHMD", rightControllerToHMD.y);
+                    }
+                    currentTime = 0;
                 }
             }
             else
@@ -59,21 +132,16 @@ namespace Cognitive3D.Components
             }
         }
 
-        void ControllerTrackingIntervalEnd()
+        /// <summary>
+        /// Increments cooldown timer and checks if cooldown time has elapsed
+        /// </summary>
+        /// <param name="deltaTime">Time elapsed since last frame</param>
+        private void UpdateCooldownClock(float deltaTime)
         {
-            Transform leftController;
-            Transform rightController;
-            if (GameplayReferences.GetControllerTransform(false, out leftController))
-            {
-                float leftControllerToHead = leftController.position.y - GameplayReferences.HMD.position.y;
-                SensorRecorder.RecordDataPoint("c3d.controller.left.height.fromHMD", leftControllerToHead);
-            }
-            if (GameplayReferences.GetControllerTransform(true, out rightController))
-            {
-                float rightControllerToHead = rightController.position.y - GameplayReferences.HMD.position.y;
-                SensorRecorder.RecordDataPoint("c3d.controller.right.height.fromHMD", rightControllerToHead);
-            }
-            currentTime = 0;
+            if (inRightCooldown) { rightCooldownTimer += deltaTime; }
+            if (rightCooldownTimer >= RIGHT_TRACKING_COOLDOWN_TIME_IN_SECONDS) { inRightCooldown = false; }
+            if (inLeftCooldown) { leftCooldownTimer += deltaTime; }
+            if (leftCooldownTimer >= LEFT_TRACKING_COOLDOWN_TIME_IN_SECONDS) { inLeftCooldown = false; }
         }
 
         private void Cleanup()


### PR DESCRIPTION
# Description

We were getting multiple back to back `Controller Lost Tracking` events. This usually happened when controllers went out of, and back in tracking range quickly within a short time. Also happened when controllers were at 90 degrees from HMD. 

We are now introducing a cooldown period, so we don't have multiple lost events repeatedly. Also, to get an idea of what angle causes controller lost events, we have an angle as an event property.

Height Task ID(s) (If applicable): 
- https://c3d.height.app/T-5097
- https://c3d.height.app/T-5098

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
