### PR TITLE
Inactivity Popup Feature in Unity Editor

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -56,7 +56,7 @@ namespace Cognitive3D
                 EditorApplication.playModeStateChanged += ModeChanged;
             }
 
-            EditorApplication.playModeStateChanged += UserActivityStatus;
+            EditorUtils.Init();
         }
 
         //there's some new bug in 2021.1.15ish. creating editor window in constructor gets BaseLiveReloadAssetTracker. delay to avoid that
@@ -66,15 +66,6 @@ namespace Cognitive3D
             if (initDelay > 0) { initDelay--; return; }
             EditorApplication.update -= UpdateInitWizard;
             ProjectSetupWindow.Init();
-        }
-
-        // Checking user activity when entering play mode
-        static void UserActivityStatus(PlayModeStateChange playModeState)
-        {
-            if (playModeState == PlayModeStateChange.EnteredPlayMode && Cognitive3D_Manager.IsInitialized)
-            {
-                EditorUtils.CheckUserActivity();
-            }
         }
 
         static void ModeChanged(PlayModeStateChange playModeState)

--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -55,6 +55,8 @@ namespace Cognitive3D
                 EditorApplication.playModeStateChanged -= ModeChanged;
                 EditorApplication.playModeStateChanged += ModeChanged;
             }
+
+            EditorApplication.playModeStateChanged += UserActivityStatus;
         }
 
         //there's some new bug in 2021.1.15ish. creating editor window in constructor gets BaseLiveReloadAssetTracker. delay to avoid that
@@ -64,6 +66,15 @@ namespace Cognitive3D
             if (initDelay > 0) { initDelay--; return; }
             EditorApplication.update -= UpdateInitWizard;
             ProjectSetupWindow.Init();
+        }
+
+        // Checking user activity when entering play mode
+        static void UserActivityStatus(PlayModeStateChange playModeState)
+        {
+            if (playModeState == PlayModeStateChange.EnteredPlayMode && Cognitive3D_Manager.IsInitialized)
+            {
+                EditorUtils.CheckUserActivity();
+            }
         }
 
         static void ModeChanged(PlayModeStateChange playModeState)

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -43,10 +43,9 @@ namespace Cognitive3D
                 {
                     await WaitForUser();
 
-                    // Check if still in play or pause mode before initializing the window
+                    // Check if still in play before initializing the window
                     if (EditorApplication.isPlaying && !IsUserPresent())
                     {
-                        // EditorApplication.pauseStateChanged
                         OpenWindow("Session Reminder");
                         await WaitingForUserResponse();
                     }
@@ -110,7 +109,6 @@ namespace Cognitive3D
             if (!buttonPressed)
             {
                 CloseWindow();
-                // EditorApplication.ExitPlaymode();
                 EditorApplication.isPaused = true;
             }
         }

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -17,12 +17,12 @@ namespace Cognitive3D
         /// <summary>
         /// Max wait time for user inactivity before displaying popup
         /// </summary>
-        private const float MAX_USER_INACTIVITY_IN_SECONDS = 5;
+        private const float MAX_USER_INACTIVITY_IN_SECONDS = 900;
 
         /// <summary>
         /// Max time to wait for user response
         /// </summary>
-        private const float WAIT_TIME_USER_RESPONSE_SECONDS = 5;
+        private const float WAIT_TIME_USER_RESPONSE_SECONDS = 1200;
 
         private const string LOG_TAG = "[COGNITIVE3D] ";
 

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -1,0 +1,121 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEngine.XR;
+using System.Threading.Tasks;
+
+
+namespace Cognitive3D
+{
+    public class EditorUtils : EditorWindow
+    {
+        const float initialDelay = 2;
+        const float interval = 900;
+        const float waitTime = 1200;
+
+        static bool buttonPressed;
+        static EditorUtils window;
+        
+
+        // 15 minute wait time starts when user becomes inactive (headset is unmounted)
+        public static async void CheckUserActivity()
+        {
+            await Task.Delay((int)initialDelay * 1000);
+            
+            if (EditorApplication.isPlaying)
+            {
+                if (!IsUserPresent())
+                {
+                    await Task.Delay((int)interval * 1000);
+
+                    // Check if still in play mode before initializing the window
+                    if (EditorApplication.isPlaying)
+                    {
+                        Init();
+                    }
+
+                    await WaitingForUserResponse();
+                }
+
+                CheckUserActivity();
+            }
+            
+        }
+
+        internal static void Init()
+        {
+            window = (EditorUtils)EditorWindow.GetWindow(typeof(EditorUtils), true, "Session Reminder");
+            window.minSize = new Vector2(400, 200);
+            window.maxSize = new Vector2(400, 200);
+
+            window.Show();
+
+            buttonPressed = false;
+        }
+
+        static void CloseWindow()
+        {
+            if (window != null)
+            {
+                window.Close();
+            }
+        }
+
+        // Waiting for user respond
+        // If there is no response, the window will be closed after 20 mins and will exit editor's play mode
+        static async Task WaitingForUserResponse()
+        {
+            float time = 0;
+
+            // Waiting for 20 minutes
+            while(time < waitTime && !buttonPressed)
+            {
+                await Task.Yield();
+                time += Time.deltaTime;
+            }
+
+            // Verifying that no user response has been made
+            // If the user has pressed a "continue" button and responded, play mode should not be exited.
+            if (!buttonPressed)
+            {
+                CloseWindow();
+                EditorApplication.ExitPlaymode();
+            }
+        }
+
+        static void OnButtonPressed()
+        {
+            buttonPressed = true;
+            CloseWindow();
+        }
+
+        // Checks whether the headset is currently worn by the user
+        public static bool IsUserPresent()
+        {
+            bool isPresent;
+
+            InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
+            currentHmd.TryGetFeatureValue(CommonUsages.userPresence, out isPresent);
+
+            return isPresent;
+        }
+
+        void OnGUI()
+        {
+            GUI.skin = EditorCore.WizardGUISkin;
+            GUI.DrawTexture(new Rect(0, 0, 400, 200), EditorGUIUtility.whiteTexture);
+
+            GUI.Label(new Rect(30, 20, 350, 300), "Do you want to continue recording this session?\n\n" + "Press 'Continue' to keep recording or 'Stop' to end the session.", "normallabel");
+
+            if (GUI.Button(new Rect(200, 150, 80, 30), new GUIContent("Continue")))
+            {
+                OnButtonPressed();
+            }
+
+            if (GUI.Button(new Rect(300, 150, 80, 30), new GUIContent("Stop")))
+            {
+                OnButtonPressed();
+                EditorApplication.ExitPlaymode();
+            }
+        }
+    }
+}

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 using UnityEngine.XR;
@@ -108,8 +109,24 @@ namespace Cognitive3D
         {
             bool isPresent;
 
+#if C3D_OCULUS
             InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
             currentHmd.TryGetFeatureValue(CommonUsages.userPresence, out isPresent);
+#elif C3D_DEFAULT
+            Vector3 velocity;
+            InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
+
+            currentHmd.TryGetFeatureValue(CommonUsages.deviceVelocity, out velocity);
+
+            if (velocity != Vector3.zero)
+            {
+                isPresent = true;
+            }
+            else
+            {
+                isPresent = false;
+            }
+#endif
 
             return isPresent;
         }

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -112,7 +112,7 @@ namespace Cognitive3D
 #if C3D_OCULUS
             InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
             currentHmd.TryGetFeatureValue(CommonUsages.userPresence, out isPresent);
-#elif C3D_DEFAULT
+#else
             Vector3 velocity;
             InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
 

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -17,17 +17,18 @@ namespace Cognitive3D
         /// <summary>
         /// Max wait time for user inactivity before displaying popup
         /// </summary>
-        private const float MAX_USER_INACTIVITY_IN_SECONDS = 900;
+        private const float MAX_USER_INACTIVITY_IN_SECONDS = 5;
 
         /// <summary>
         /// Max time to wait for user response
         /// </summary>
-        private const float WAIT_TIME_USER_RESPONSE_SECONDS = 1200;
+        private const float WAIT_TIME_USER_RESPONSE_SECONDS = 5;
 
         private const string LOG_TAG = "[COGNITIVE3D] ";
 
         private static bool buttonPressed;
         private static EditorUtils window;
+        private static bool pause;
 
         public static void Init()
         {
@@ -78,12 +79,15 @@ namespace Cognitive3D
             if (pauseState == PauseState.Paused)
             {
                 Util.logDebug("Session Paused");
-                OpenWindow(LOG_TAG + "Session Paused");
+                if (pause)
+                {
+                    OpenWindow(LOG_TAG + "Session Paused");
+                }
+                return;
             }
-            else
-            {
-                Util.logDebug("Session Continued");
-            }
+
+            Util.logDebug("Session Continued");
+            pause = false;
         }
 
         private static void OpenWindow(string windowTitle)
@@ -123,6 +127,7 @@ namespace Cognitive3D
             if (!buttonPressed)
             {
                 CloseWindow();
+                pause = true;
                 EditorApplication.isPaused = true;
             }
         }

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -147,15 +147,15 @@ namespace Cognitive3D
         /// <summary>
         /// Checks whether the headset is currently worn by the user in Editor
         /// </summary>
+        /// TODO: Need support for other SDKs
         private static bool IsUserPresent()
         {
-            bool isPresent;
-
 #if C3D_OCULUS
+            bool isPresent;
             InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
             currentHmd.TryGetFeatureValue(CommonUsages.userPresence, out isPresent);
+            return isPresent;
 #elif C3D_DEFAULT
-            // Work with Vive focus?
             Vector3 velocity;
             InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
 
@@ -163,15 +163,14 @@ namespace Cognitive3D
 
             if (velocity != Vector3.zero)
             {
-                isPresent = true;
+                return true;
             }
             else
             {
-                isPresent = false;
+                return false;
             }
-#else
-            return true;
 #endif       
+            return true;
         }
 
         private void OnGUI()

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -25,15 +25,15 @@ namespace Cognitive3D
             {
                 if (!IsUserPresent())
                 {
-                    await Task.Delay((int)interval * 1000);
+                    await WaitForUser();
 
                     // Check if still in play mode before initializing the window
-                    if (EditorApplication.isPlaying)
+                    if (EditorApplication.isPlaying && !IsUserPresent())
                     {
                         Init();
-                    }
 
-                    await WaitingForUserResponse();
+                        await WaitingForUserResponse();
+                    }
                 }
 
                 CheckUserActivity();
@@ -79,6 +79,21 @@ namespace Cognitive3D
             {
                 CloseWindow();
                 EditorApplication.ExitPlaymode();
+            }
+        }
+
+        // Waiting for user to become active
+        // If user become active and put their headset back, wait time will stop
+        static async Task WaitForUser()
+        {
+            float time = 0;
+
+            // Waiting for 15 minutes
+            // If user is active again during wait time, breaks out of wait loop
+            while(time < interval && !IsUserPresent())
+            {
+                await Task.Yield();
+                time += Time.deltaTime;
             }
         }
 

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -12,18 +12,22 @@ namespace Cognitive3D
         /// </summary>
         // To ensure accurate user presence detection upon entering play mode
         // User presence returns false within 1 second of entering play mode
-        const float INTERVAL_IN_SECONDS = 2;
+        private const float INTERVAL_IN_SECONDS = 2;
+
         /// <summary>
         /// Max wait time for user inactivity before displaying popup
         /// </summary>
-        const float MAX_USER_INACTIVITY_IN_SECONDS = 900;
+        private const float MAX_USER_INACTIVITY_IN_SECONDS = 900;
+
         /// <summary>
         /// Max time to wait for user response
         /// </summary>
-        const float WAIT_TIME_USER_RESPONSE_SECONDS = 1200;
+        private const float WAIT_TIME_USER_RESPONSE_SECONDS = 1200;
 
-        static bool buttonPressed;
-        static EditorUtils window;
+        private const string LOG_TAG = "[COGNITIVE3D] ";
+
+        private static bool buttonPressed;
+        private static EditorUtils window;
 
         public static void Init()
         {
@@ -56,7 +60,7 @@ namespace Cognitive3D
                     // Check if still in play before initializing the window
                     if (EditorApplication.isPlaying && !IsUserPresent())
                     {
-                        OpenWindow("Session Reminder");
+                        OpenWindow(LOG_TAG + "Session Reminder");
                         await WaitingForUserResponse();
                     }
                 }
@@ -74,7 +78,7 @@ namespace Cognitive3D
             if (pauseState == PauseState.Paused)
             {
                 Util.logDebug("Session Paused");
-                OpenWindow("Session Paused");
+                OpenWindow(LOG_TAG + "Session Paused");
             }
             else
             {
@@ -85,8 +89,8 @@ namespace Cognitive3D
         private static void OpenWindow(string windowTitle)
         {
             window = (EditorUtils)EditorWindow.GetWindow(typeof(EditorUtils), true, windowTitle);
-            window.minSize = new Vector2(400, 200);
-            window.maxSize = new Vector2(400, 200);
+            window.minSize = new Vector2(480, 210);
+            window.maxSize = new Vector2(480, 210);
 
             window.Show();
 
@@ -169,25 +173,35 @@ namespace Cognitive3D
             {
                 return false;
             }
-#endif       
+#else
             return true;
+#endif
         }
 
         private void OnGUI()
         {
             GUI.skin = EditorCore.WizardGUISkin;
-            GUI.DrawTexture(new Rect(0, 0, 400, 200), EditorGUIUtility.whiteTexture);
+            GUI.DrawTexture(new Rect(0, 0, 480, 210), EditorGUIUtility.whiteTexture);
 
-            if (titleContent.text == "Session Reminder")
+            // Define the coordinates and dimensions of the cropping area
+            Rect cropArea = new Rect(20, 40, 110, 100);
+
+            // Begin a group with the cropping area
+            GUI.BeginGroup(cropArea);
+            // Draw the image within the cropping area
+            GUI.Label(new Rect(-50, 0, 400, 80), EditorCore.LogoTexture, "image_centered");
+            // End the group
+            GUI.EndGroup();
+
+            if (titleContent.text == LOG_TAG + "Session Reminder")
             {
-                GUI.Label(new Rect(30, 20, 350, 300), "Do you want to continue recording this session?\n\n" + "Press 'Continue' to keep recording or 'Stop' to end the session.", "normallabel");
-
-                if (GUI.Button(new Rect(200, 150, 80, 30), new GUIContent("Continue")))
+                GUI.Label(new Rect(150, 30, 300, 800), "Do you want to continue recording this session?\n\n" + "Press 'Continue' to keep recording or 'Stop' to end the session.", "normallabel");
+                if (GUI.Button(new Rect(230, 150, 100, 30), new GUIContent("Continue")))
                 {
                     OnButtonPressed();
                 }
 
-                if (GUI.Button(new Rect(300, 150, 80, 30), new GUIContent("Stop")))
+                if (GUI.Button(new Rect(350, 150, 100, 30), new GUIContent("Stop")))
                 {
                     OnButtonPressed();
                     EditorApplication.ExitPlaymode();
@@ -195,9 +209,9 @@ namespace Cognitive3D
             }
             else
             {
-                GUI.Label(new Rect(30, 20, 350, 300), "Editor (session) is paused due to inactivity!", "normallabel");
+                GUI.Label(new Rect(150, 60, 300, 800), "Unity Editor session has been paused due to inactivity.", "normallabel");
 
-                if (GUI.Button(new Rect(165, 150, 80, 30), new GUIContent("OK")))
+                if (GUI.Button(new Rect(200, 150, 100, 30), new GUIContent("OK")))
                 {
                     OnButtonPressed();
                 }

--- a/Editor/EditorUtils.cs.meta
+++ b/Editor/EditorUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e958d1fe150981f43afb5b0f4202ac84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/EditorUtils.cs.meta
+++ b/Editor/EditorUtils.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e958d1fe150981f43afb5b0f4202ac84
+guid: 992ead031abae5541a7b6db94df122f4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
# Description

Displaying a popup after 15 minutes of inactivity

- Added `EditorUtils.cs` under `Runtime` for managing inactivity-related functionalities
- Handling 15 minutes wait time after user unmounts headset
- Added a 20-minute waiting period for user response after displaying the popup
- Updated `EditorCore.cs` to subscribe to the user activity checking process when entering Unity Editor play mode

Height Task ID(s) (If applicable): https://c3d.height.app/T-4771

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
