### PR TITLE
Check controller tracking before recording armlength

### DIFF
--- a/Runtime/Components/ArmLength.cs
+++ b/Runtime/Components/ArmLength.cs
@@ -39,7 +39,7 @@ namespace Cognitive3D.Components
 
                 bool includedSample = false;
 
-                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.LeftHand))
+                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.LeftHand) && GameplayReferences.IsLeftControllerTracking())
                 {
                     if (GameplayReferences.GetControllerTransform(false, out tempInfo))
                     {
@@ -48,7 +48,7 @@ namespace Cognitive3D.Components
                     }
                 }
 
-                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.RightHand))
+                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.RightHand) && GameplayReferences.IsRightControllerTracking())
                 {
                     if (GameplayReferences.GetControllerTransform(true, out tempInfo))
                     {

--- a/Runtime/Components/ArmLength.cs
+++ b/Runtime/Components/ArmLength.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
+using UnityEngine.XR;
 #if C3D_STEAMVR || C3D_STEAMVR2
 using Valve.VR;
 #endif
@@ -39,7 +40,7 @@ namespace Cognitive3D.Components
 
                 bool includedSample = false;
 
-                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.LeftHand) && GameplayReferences.IsLeftControllerTracking())
+                if (GameplayReferences.IsInputDeviceValid(XRNode.LeftHand) && GameplayReferences.IsControllerTracking(XRNode.LeftHand))
                 {
                     if (GameplayReferences.GetControllerTransform(false, out tempInfo))
                     {
@@ -48,7 +49,7 @@ namespace Cognitive3D.Components
                     }
                 }
 
-                if (GameplayReferences.IsInputDeviceValid(UnityEngine.XR.XRNode.RightHand) && GameplayReferences.IsRightControllerTracking())
+                if (GameplayReferences.IsInputDeviceValid(XRNode.RightHand) && GameplayReferences.IsControllerTracking(XRNode.RightHand))
                 {
                     if (GameplayReferences.GetControllerTransform(true, out tempInfo))
                     {

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -365,26 +365,14 @@ namespace Cognitive3D
         /// Returns whether the left controller is currently tracked.
         /// Uses InputDevice.TryGetFeatureUsage API
         /// </summary>
-        /// <returns> True if left controller is tracking; false otherwise </returns>
-        public static bool IsLeftControllerTracking()
+        /// <param name="hand"> The XRNode; either left hand or right hand</param>
+        /// <returns>True if left controller is tracking; false otherwise</returns>
+        public static bool IsControllerTracking(XRNode hand)
         {
-            InputDevice leftController = InputDevices.GetDeviceAtXRNode(XRNode.LeftHand);
-            bool isLeftControllerTrackingRef;
-            leftController.TryGetFeatureValue(CommonUsages.isTracked, out isLeftControllerTrackingRef);
-            return isLeftControllerTrackingRef;
-        }
-
-        /// <summary>
-        /// Returns whether the right controller is currently tracked.
-        /// Uses InputDevice.TryGetFeatureUsage API
-        /// </summary>
-        /// <returns> True if right controller is tracking; false otherwise </returns>
-        public static bool IsRightControllerTracking()
-        {
-            InputDevice rightController = InputDevices.GetDeviceAtXRNode(XRNode.RightHand);
-            bool isRightControllerTrackingRef;
-            rightController.TryGetFeatureValue(CommonUsages.isTracked, out isRightControllerTrackingRef);
-            return isRightControllerTrackingRef;
+            InputDevice controller = InputDevices.GetDeviceAtXRNode(hand);
+            bool isControllerTrackingRef;
+            controller.TryGetFeatureValue(CommonUsages.isTracked, out isControllerTrackingRef);
+            return isControllerTrackingRef;
         }
 
         public static IControllerPointer ControllerPointerLeft;

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -361,6 +361,32 @@ namespace Cognitive3D
             }
         }
 
+        /// <summary>
+        /// Returns whether the left controller is currently tracked.
+        /// Uses InputDevice.TryGetFeatureUsage API
+        /// </summary>
+        /// <returns> True if left controller is tracking; false otherwise </returns>
+        public static bool IsLeftControllerTracking()
+        {
+            InputDevice leftController = InputDevices.GetDeviceAtXRNode(XRNode.LeftHand);
+            bool isLeftControllerTrackingRef;
+            leftController.TryGetFeatureValue(CommonUsages.isTracked, out isLeftControllerTrackingRef);
+            return isLeftControllerTrackingRef;
+        }
+
+        /// <summary>
+        /// Returns whether the right controller is currently tracked.
+        /// Uses InputDevice.TryGetFeatureUsage API
+        /// </summary>
+        /// <returns> True if right controller is tracking; false otherwise </returns>
+        public static bool IsRightControllerTracking()
+        {
+            InputDevice rightController = InputDevices.GetDeviceAtXRNode(XRNode.RightHand);
+            bool isRightControllerTrackingRef;
+            rightController.TryGetFeatureValue(CommonUsages.isTracked, out isRightControllerTrackingRef);
+            return isRightControllerTrackingRef;
+        }
+
         public static IControllerPointer ControllerPointerLeft;
         public static IControllerPointer ControllerPointerRight;
 


### PR DESCRIPTION
# Description

To make the `ArmLength` component more robust and prevent incorrect or misleading values, we are going to check if the controller is tracked before we use it's position to record arm length.

Height Task ID(s) (If applicable): https://c3d.height.app/T-5255

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
