### PR TITLE
Fix for No Active Oculus Display Subsystem Found

### DIFF
--- a/Runtime/Components/OculusHardware.cs
+++ b/Runtime/Components/OculusHardware.cs
@@ -26,7 +26,7 @@ namespace Cognitive3D.Components
             var wait = new WaitForSeconds(1);
             yield return wait;
 
-            if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("Oculus"))
+            if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("oculus"))
             {
                 while (Cognitive3D.Cognitive3D_Manager.IsInitialized)
                 {

--- a/Runtime/Components/OculusHardware.cs
+++ b/Runtime/Components/OculusHardware.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
 using UnityEngine;
+using UnityEngine.XR;
+using System.Collections.Generic;
+
 #if C3D_OCULUS
 using Unity.XR.Oculus;
 #endif
@@ -21,10 +24,19 @@ namespace Cognitive3D.Components
         IEnumerator OneSecondTick()
         {
             var wait = new WaitForSeconds(1);
-            while (Cognitive3D.Cognitive3D_Manager.IsInitialized)
+            yield return wait;
+
+            if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("Oculus"))
             {
-                yield return wait;
-                RecordOculusStats();
+                while (Cognitive3D.Cognitive3D_Manager.IsInitialized)
+                {
+                    yield return wait;
+                    RecordOculusStats();
+                }
+            }
+            else if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("OpenXR"))
+            {
+                Debug.LogWarning("Oculus Hardware sensors cannot be accessed while using OpenXR plugin");
             }
         }
 
@@ -55,7 +67,7 @@ namespace Cognitive3D.Components
 #if C3D_OCULUS
             return "Records Battery level, CPU level, GPU level and Power Saving mode states";
 #else
-            return "Oculus Hardware senosrs can only be accessed when using the Oculus Integration SDK";
+            return "Oculus Hardware sensors can only be accessed when using the Oculus Integration SDK";
 #endif
         }
         public override bool GetWarning()
@@ -65,6 +77,29 @@ namespace Cognitive3D.Components
 #else
             return true;
 #endif
+        }
+
+        private static XRDisplaySubsystem activeDisplay;
+
+        private static XRDisplaySubsystem GetActiveDisplaySubsystem()
+        {
+            if (activeDisplay != null)
+                return activeDisplay;
+
+            List<XRDisplaySubsystem> displays = new List<XRDisplaySubsystem>();
+            SubsystemManager.GetSubsystems(displays);
+
+            foreach (XRDisplaySubsystem xrDisplaySubsystem in displays)
+            {
+                if (xrDisplaySubsystem.running)
+                {
+                    activeDisplay = xrDisplaySubsystem;
+                    return activeDisplay;
+                }
+            }
+
+            Debug.LogError("No active display subsystem was found.");
+            return activeDisplay;
         }
     }
 


### PR DESCRIPTION
# Description

The following changes are made to fix "No Active Oculus Display Subsystem Found" error:

- Implemented `GetActiveDisplaySubsystem()` to retrieve the active display subsystem.
- Check to verify if the active display subsystem is` Oculus`. In the case of `OpenXR`, `Oculus hardware` data collection is skipped, and a warning is logged in the console (displayed only once at the start of the session).
- Added a 1-second delay before checking the active display subsystem
- Fixed a misspelling in `GetDescription()`

Height Task ID(s) (If applicable): https://c3d.height.app/T-4946

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
