### PR TITLE
Simplify oculus social

### DIFF
--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -12,7 +12,7 @@ namespace Cognitive3D.Components
     public class OculusSocial : AnalyticsComponentBase
     {
 #if C3D_OCULUS
-        [Tooltip("Used to record user data like username, id, and display name. Sessions will be named as users' display name in the session list.")]
+        [Tooltip("Used to record user data like username, id, and display name. Sessions will be named as users' display name in the session list. Allows tracking users across different sessions.")]
         [SerializeField]
         private bool RecordOculusUserData = true;
 #endif

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -12,13 +12,9 @@ namespace Cognitive3D.Components
     public class OculusSocial : AnalyticsComponentBase
     {
 #if C3D_OCULUS
-        [Tooltip("Used to automatically associate a profile to a participant. Allows tracking between different sessions")]
+        [Tooltip("Used to record user data like username, id, and display name. Sessions will be named as users' display name in the session list.")]
         [SerializeField]
-        private bool AssignOculusProfileToParticipant = false;
-
-        [Tooltip("Used to automatically set user's display name as participant name on the dashboard")]
-        [SerializeField]
-        private bool AssignOculusNameToParticipantName = false;
+        private bool RecordOculusUserData = true;
 #endif
 
         protected override void OnSessionBegin()
@@ -107,7 +103,7 @@ namespace Cognitive3D.Components
                 }
 
                 Users.Get(message.Data.ID).OnComplete(DisplayNameCallback);
-                if (AssignOculusProfileToParticipant)
+                if (RecordOculusUserData)
                 {
                     Cognitive3D_Manager.SetParticipantId(id);
                 }
@@ -131,7 +127,7 @@ namespace Cognitive3D.Components
 #endif
             {
                 Cognitive3D_Manager.SetParticipantProperty("oculusDisplayName", displayName);
-                if (AssignOculusNameToParticipantName)
+                if (RecordOculusUserData)
                 {
                     Cognitive3D_Manager.SetParticipantFullName(displayName);
                 }


### PR DESCRIPTION
# Description

We are simplifiyng the options on the `OculusSocial` component. This includes renaming the variables, simplifying to one toggle, and making it default to `true`.

Height Task ID(s) (If applicable): https://c3d.height.app/T-4864

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
