### PR TITLE
HandTracking: Remove sensor; improve events

### DIFF
--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -22,7 +22,6 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-            CaptureHandTrackingEvents();
             Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", true);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -17,9 +17,6 @@ namespace Cognitive3D.Components
             Hand = 2
         }
 
-        private readonly float HandTrackingSendInterval = 1;
-        private float currentTime = 0;
-
         private TrackingType lastTrackedDevice = TrackingType.None;
 
         protected override void OnSessionBegin()
@@ -38,13 +35,7 @@ namespace Cognitive3D.Components
             //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()
             if (isActiveAndEnabled)
             {
-                currentTime += deltaTime;
-
-                if (currentTime > HandTrackingSendInterval)
-                {
-                    currentTime = 0;
-                    CaptureHandTrackingEvents();
-                }
+                CaptureHandTrackingEvents();
             }
             else
             {
@@ -58,14 +49,14 @@ namespace Cognitive3D.Components
         /// <returns> Enum representing whether user is using hand or controller or neither </returns>
         TrackingType GetCurrentTrackedDevice()
         {
-            var currentTrackedDevice = OVRInput.GetActiveController();
-            if (currentTrackedDevice == OVRInput.Controller.None)
+            var currentOVRTrackedDevice = OVRInput.GetActiveController();
+            if (currentOVRTrackedDevice == OVRInput.Controller.None)
             {
                 return TrackingType.None;
             }
-            else if (currentTrackedDevice == OVRInput.Controller.Hands
-                || currentTrackedDevice == OVRInput.Controller.LHand
-                || currentTrackedDevice == OVRInput.Controller.RHand)
+            else if (currentOVRTrackedDevice == OVRInput.Controller.Hands
+                || currentOVRTrackedDevice == OVRInput.Controller.LHand
+                || currentOVRTrackedDevice == OVRInput.Controller.RHand)
             {
                 return TrackingType.Hand;
             }

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -25,7 +25,7 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-            lastTrackedDevice = GetCurrentTrackedDevice();
+            CaptureHandTrackingEvents();
             Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", true);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
@@ -43,9 +43,7 @@ namespace Cognitive3D.Components
                 if (currentTime > HandTrackingSendInterval)
                 {
                     currentTime = 0;
-                    var currentTrackedDevice = GetCurrentTrackedDevice();
-                    CaptureHandTrackingEvents(currentTrackedDevice);
-                    SensorRecorder.RecordDataPoint("c3d.input.tracking", (int)currentTrackedDevice);
+                    CaptureHandTrackingEvents();
                 }
             }
             else
@@ -80,8 +78,9 @@ namespace Cognitive3D.Components
         /// <summary>
         /// Captures any change in input device from hand to controller to none or vice versa
         /// </summary>
-        void CaptureHandTrackingEvents(TrackingType currentTrackedDevice)
+        void CaptureHandTrackingEvents()
         {
+            var currentTrackedDevice = GetCurrentTrackedDevice();
             if (lastTrackedDevice != currentTrackedDevice)
             {
                 new CustomEvent("c3d.input.tracking.changed")


### PR DESCRIPTION
# Description

Height Task ID(s) (If applicable): https://c3d.height.app/T-5286, https://c3d.height.app/T-5316

## Type of change

We are removing the sensor stream representing hands-vs-contoller. In addition, we are adding an event on `SessionBegin()` so we can track controller events from beginning to end.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
