### PR TITLE
Fix dynamic for hand tracking

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -796,7 +796,6 @@ namespace Cognitive3D
                 if (hand == null)
                 {
                     Cognitive3D_Manager.Instance.gameObject.AddComponent<HandTracking>();
-                    GameplayReferences.handTrackingEnabled = true;
                 }
             }
             else

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -796,6 +796,7 @@ namespace Cognitive3D
                 if (hand == null)
                 {
                     Cognitive3D_Manager.Instance.gameObject.AddComponent<HandTracking>();
+                    GameplayReferences.handTrackingEnabled = true;
                 }
             }
             else

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -7,26 +7,17 @@ namespace Cognitive3D.Components
     public class HandTracking : AnalyticsComponentBase
     {
 #if C3D_OCULUS
-        /// <summary>
-        /// Represents participant is using hands, controller, or neither
-        /// </summary>
-        private enum TrackingType
-        {
-            None = 0,
-            Controller = 1,
-            Hand = 2
-        }
 
         private readonly float HandTrackingSendInterval = 1;
         private float currentTime = 0;
 
-        private TrackingType lastTrackedDevice = TrackingType.None;
+        private GameplayReferences.TrackingType lastTrackedDevice = GameplayReferences.TrackingType.None;
 
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-            lastTrackedDevice = GetCurrentTrackedDevice();
-            Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", true);
+            lastTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
+            Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", GameplayReferences.handTrackingEnabled);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
         }
@@ -43,9 +34,8 @@ namespace Cognitive3D.Components
                 if (currentTime > HandTrackingSendInterval)
                 {
                     currentTime = 0;
-                    var currentTrackedDevice = GetCurrentTrackedDevice();
+                    var currentTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
                     CaptureHandTrackingEvents(currentTrackedDevice);
-                    SensorRecorder.RecordDataPoint("c3d.input.tracking", (int)currentTrackedDevice);
                 }
             }
             else
@@ -55,32 +45,9 @@ namespace Cognitive3D.Components
         }
 
         /// <summary>
-        /// Gets the current tracked device i.e. hand or controller
-        /// </summary>
-        /// <returns> Enum representing whether user is using hand or controller or neither </returns>
-        TrackingType GetCurrentTrackedDevice()
-        {
-            var currentTrackedDevice = OVRInput.GetActiveController();
-            if (currentTrackedDevice == OVRInput.Controller.None)
-            {
-                return TrackingType.None;
-            }
-            else if (currentTrackedDevice == OVRInput.Controller.Hands
-                || currentTrackedDevice == OVRInput.Controller.LHand
-                || currentTrackedDevice == OVRInput.Controller.RHand)
-            {
-                return TrackingType.Hand;
-            }
-            else
-            {
-                return TrackingType.Controller;
-            }
-        }
-
-        /// <summary>
         /// Captures any change in input device from hand to controller to none or vice versa
         /// </summary>
-        void CaptureHandTrackingEvents(TrackingType currentTrackedDevice)
+        void CaptureHandTrackingEvents(GameplayReferences.TrackingType currentTrackedDevice)
         {
             if (lastTrackedDevice != currentTrackedDevice)
             {

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -17,6 +17,7 @@ namespace Cognitive3D.Components
         {
             base.OnSessionBegin();
             lastTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
+            GameplayReferences.handTrackingEnabled = true; // have to do it here because doing it from scene setup doesn't work
             Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", GameplayReferences.handTrackingEnabled);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -7,9 +7,6 @@ namespace Cognitive3D.Components
     public class HandTracking : AnalyticsComponentBase
     {
 #if C3D_OCULUS
-        private readonly float HandTrackingSendInterval = 1;
-        private float currentTime = 0;
-
         private GameplayReferences.TrackingType lastTrackedDevice = GameplayReferences.TrackingType.None;
 
         protected override void OnSessionBegin()
@@ -29,14 +26,8 @@ namespace Cognitive3D.Components
             //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()
             if (isActiveAndEnabled)
             {
-                currentTime += deltaTime;
-
-                if (currentTime > HandTrackingSendInterval)
-                {
-                    currentTime = 0;
                     var currentTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
                     CaptureHandTrackingEvents(currentTrackedDevice);
-                }
             }
             else
             {
@@ -49,7 +40,6 @@ namespace Cognitive3D.Components
         /// </summary>
         void CaptureHandTrackingEvents(GameplayReferences.TrackingType currentTrackedDevice)
         {
-            var currentTrackedDevice = GetCurrentTrackedDevice();
             if (lastTrackedDevice != currentTrackedDevice)
             {
                 new CustomEvent("c3d.input.tracking.changed")

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -183,7 +183,23 @@ namespace Cognitive3D
 
             //if a controller, delay registering the controller until the controller name has returned something valid
             if (IsController)
-            {
+            {            
+                // Special case for hand tracking (particularly when session begins with hand): 
+                    //  need this because InputDevice.isValid returns false
+                    //  and InputDevice.name gives us nothing
+                if (GameplayReferences.handTrackingEnabled)
+                {
+#if C3D_OCULUS
+                    // If starting with hands; use fallback controller
+                    if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand)
+                    {
+                        // just quickly look up controller by type, isRight
+                        registerMeshName = SetupFallbackControllerAndReturnName();
+                        return;
+                    }
+#endif
+                }
+
                 GameplayReferences.SetController(this, IsRight);
                 if (IdentifyControllerAtRuntime)
                 {
@@ -204,16 +220,14 @@ namespace Cognitive3D
                             commonDynamicMesh == CommonDynamicMesh.Unknown)
                         {
                             //failed to identify the controller - use the fallback
-                            SetControllerFromFallback(FallbackControllerType, IsRight);
-                            registerMeshName = commonDynamicMesh.ToString();
+                            registerMeshName = SetupFallbackControllerAndReturnName();
                         }
                     }
                 }
                 else
                 {
                     //just quickly look up controller by type, isRight
-                    SetControllerFromFallback(FallbackControllerType, IsRight);
-                    registerMeshName = commonDynamicMesh.ToString();
+                    registerMeshName = SetupFallbackControllerAndReturnName();
                 }
             }
 
@@ -259,6 +273,12 @@ namespace Cognitive3D
             }
             mesh = commonDynamicMesh;
             display = controllerDisplayType;
+        }
+
+        private string SetupFallbackControllerAndReturnName()
+        {
+            SetControllerFromFallback(FallbackControllerType, IsRight);
+            return commonDynamicMesh.ToString();
         }
 
         //sets the class variables from the fallback controller type

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -193,7 +193,8 @@ namespace Cognitive3D
                     if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand)
                     {
                         // just quickly look up controller by type, isRight
-                        registerMeshName = SetupFallbackControllerAndReturnName();
+                        SetControllerFromFallback(FallbackControllerType, IsRight);
+                        registerMeshName = commonDynamicMesh.ToString();
                         return;
                     }
                 }
@@ -218,14 +219,16 @@ namespace Cognitive3D
                             commonDynamicMesh == CommonDynamicMesh.Unknown)
                         {
                             //failed to identify the controller - use the fallback
-                            registerMeshName = SetupFallbackControllerAndReturnName();
+                            SetControllerFromFallback(FallbackControllerType, IsRight);
+                            registerMeshName = commonDynamicMesh.ToString();
                         }
                     }
                 }
                 else
                 {
                     //just quickly look up controller by type, isRight
-                    registerMeshName = SetupFallbackControllerAndReturnName();
+                    SetControllerFromFallback(FallbackControllerType, IsRight);
+                    registerMeshName = commonDynamicMesh.ToString();
                 }
             }
 
@@ -271,12 +274,6 @@ namespace Cognitive3D
             }
             mesh = commonDynamicMesh;
             display = controllerDisplayType;
-        }
-
-        private string SetupFallbackControllerAndReturnName()
-        {
-            SetControllerFromFallback(FallbackControllerType, IsRight);
-            return commonDynamicMesh.ToString();
         }
 
         //sets the class variables from the fallback controller type

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -189,7 +189,6 @@ namespace Cognitive3D
                     //  and InputDevice.name gives us nothing
                 if (GameplayReferences.handTrackingEnabled)
                 {
-#if C3D_OCULUS
                     // If starting with hands; use fallback controller
                     if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand)
                     {
@@ -197,7 +196,6 @@ namespace Cognitive3D
                         registerMeshName = SetupFallbackControllerAndReturnName();
                         return;
                     }
-#endif
                 }
 
                 GameplayReferences.SetController(this, IsRight);

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -11,7 +11,7 @@ namespace Cognitive3D
     public static class GameplayReferences
     {
         public static bool handTrackingEnabled;
-#if C3D_OCULUS
+
         //face expressions is cached so it doesn't search every frame, instead just a null check. and only if eyetracking is already marked as supported
         static OVRFaceExpressions cachedOVRFaceExpressions;
 
@@ -48,7 +48,6 @@ namespace Cognitive3D
             }
         }
 
-#endif
         public static bool SDKSupportsEyeTracking
         {
             get

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -10,6 +10,7 @@ namespace Cognitive3D
 {
     public static class GameplayReferences
     {
+        public static bool handTrackingEnabled;
 #if C3D_OCULUS
         //face expressions is cached so it doesn't search every frame, instead just a null check. and only if eyetracking is already marked as supported
         static OVRFaceExpressions cachedOVRFaceExpressions;
@@ -48,9 +49,6 @@ namespace Cognitive3D
         }
 
 #endif
-
-        public static bool handTrackingEnabled = false;
-
         public static bool SDKSupportsEyeTracking
         {
             get

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -13,7 +13,43 @@ namespace Cognitive3D
 #if C3D_OCULUS
         //face expressions is cached so it doesn't search every frame, instead just a null check. and only if eyetracking is already marked as supported
         static OVRFaceExpressions cachedOVRFaceExpressions;
+
+        /// <summary>
+        /// Represents participant is using hands, controller, or neither
+        /// </summary>
+        public enum TrackingType
+        {
+            None = 0,
+            Controller = 1,
+            Hand = 2
+        }
+
+        /// <summary>
+        /// Oculus SeGets the current tracked device i.e. hand or controller
+        /// </summary>
+        /// <returns> Enum representing whether user is using hand or controller or neither </returns>
+        public static TrackingType GetCurrentTrackedDevice()
+        {
+            var currentTrackedDevice = OVRInput.GetActiveController();
+            if (currentTrackedDevice == OVRInput.Controller.None)
+            {
+                return TrackingType.None;
+            }
+            else if (currentTrackedDevice == OVRInput.Controller.Hands
+                || currentTrackedDevice == OVRInput.Controller.LHand
+                || currentTrackedDevice == OVRInput.Controller.RHand)
+            {
+                return TrackingType.Hand;
+            }
+            else
+            {
+                return TrackingType.Controller;
+            }
+        }
+
 #endif
+
+        public static bool handTrackingEnabled = false;
 
         public static bool SDKSupportsEyeTracking
         {


### PR DESCRIPTION
# Description

If an app has hand tracking enabled, and a session uses hands only, and controller dynamic objects are set to `IdentifyControllerAtRuntime`, the objects will never get registered, leading to the session having no dynamics on dashboard and SE. This is a workaround for that situation, currently only for Oculus, but this will likely evolve as other platforms are introduced.

### Summary
- In `DynamicObject.OnEnable()`, if hantracking is enabled, and currently using hands, use fallback controller mesh
- Current tracking type (using our own enum which we use for simplicity) now moved to `GameplayReferences.cs` so `DynamicObject.cs` can access it
- Created function for registering fallback controller and returning the name

Height Task ID(s) (If applicable): https://c3d.height.app/T-5438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
