### PR TITLE
Fix for OculusHardware compile error

### DIFF
--- a/Runtime/Components/OculusHardware.cs
+++ b/Runtime/Components/OculusHardware.cs
@@ -87,7 +87,14 @@ namespace Cognitive3D.Components
                 return activeDisplay;
 
             List<XRDisplaySubsystem> displays = new List<XRDisplaySubsystem>();
+
+            // GetSubsystems() doesn't exist for lower versions
+            // https://docs.unity3d.com/ScriptReference/SubsystemManager.GetSubsystems.html
+#if UNITY_2020_2_OR_NEWER
             SubsystemManager.GetSubsystems(displays);
+#else
+            SubsystemManager.GetInstances(displays);
+#endif
 
             foreach (XRDisplaySubsystem xrDisplaySubsystem in displays)
             {


### PR DESCRIPTION
# Description

In Unity 2020.1 and earlier versions, `OculusHardware.cs` throws a compile error. The function GetSubsystems() is not supported in Unity versions older than 2020.2.

- Added GetInstances() for the older versions of Unity which has the same functionality as GetSubsystems()

Height Task ID(s) (If applicable): https://c3d.height.app/T-5471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
