### PR TITLE
Increase scene thumbnail size; UI changes

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -1275,7 +1275,7 @@ namespace Cognitive3D
         public static RenderTexture GetSceneRenderTexture()
         {
             if (sceneRT == null)
-                sceneRT = new RenderTexture(256, 256, 24);
+                sceneRT = new RenderTexture(1024, 432, 24);
 
             var cameras = SceneView.GetAllSceneCameras();
             if (cameras != null && cameras.Length > 0 && cameras[0] != null)

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -1080,7 +1080,7 @@ namespace Cognitive3D
                         UploadThumbnail = true;
                     }
                 }
-                GUI.Label(new Rect(60, heightOffset+42, 300, 30), "Upload Scene Thumbnail", "normallabel");
+                GUI.Label(new Rect(60, heightOffset+42, 300, 30), "Upload Scene Thumbnail*", "normallabel");
             }
 
             //upload dynamics
@@ -1111,14 +1111,15 @@ namespace Cognitive3D
                     }
                 }
                 GUI.Label(new Rect(60, heightOffset+82, 300, 30), "Upload " + dynamicObjectCount + " Dynamic Meshes", "normallabel");
+                GUI.Label(new Rect(200, heightOffset+340, 300, 40), "*You can adjust the scene camera to customise your thumbnail");
             }
 
             //scene thumbnail preview
-            var thumbnailRect = new Rect(175, heightOffset+130, 150, 150);
+            var thumbnailRect = new Rect(40, heightOffset+130, 420, 180);
             Texture2D savedThumbnail = null;
             if (UploadThumbnail)
             {
-                GUI.Label(new Rect(150, heightOffset+280, 200, 20), "New Thumbnail from Scene View");
+                GUI.Label(new Rect(150, heightOffset+312, 200, 20), "New Thumbnail from Scene View");
                 var sceneRT = EditorCore.GetSceneRenderTexture();
                 if (sceneRT != null)
                     GUI.Box(thumbnailRect, sceneRT, "image_centeredboxed");


### PR DESCRIPTION
# Description

We are improving the quality of scene thumbnail from `256x256` to `1024x432`. This change also includes improvements to the scene setup window for a better UX.

### Before
![ThumbnailOld](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/e735bfbe-f8f5-42a1-948f-d525c7eac8b9)

### After
![Thumbnail](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/e9877152-de89-41e3-9b3d-e3466172e5c1)

Height Task ID(s) (If applicable): https://c3d.height.app/T-5589

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
