### PR TITLE
Determine how app was installed

### DIFF
--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -39,6 +39,10 @@ namespace Cognitive3D.Components
             {
                 Entitlements.IsUserEntitledToApplication().OnComplete(EntitlementCallback);
             }
+            else
+            {
+                Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.isUserEntitled", false);
+            }
 
             if (!string.IsNullOrEmpty(appID))
             {
@@ -70,10 +74,12 @@ namespace Cognitive3D.Components
         {
             if (message.IsError) // User failed entitlement check
             {
+                Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.isUserEntitled", false);
                 Debug.LogError("You are NOT entitled to use this app.");
             }
             else // User passed entitlement check
             {
+                Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.isUserEntitled", true);
                 // Log the succeeded entitlement check for debugging.
                 Debug.Log("You are entitled to use this app.");
                 Users.GetLoggedInUser().OnComplete(UserCallback);


### PR DESCRIPTION
# Description

This change will allow us to determine if an app was distributed and installed through Oculus App Lab/Quest store -vs- side load, Arbor install, etc.

We will use a session property `c3d.app.meta.isUserEntitled` and the value will be either `true` or `false`. The following scenarios for the values:

- The app is installed in any way other than App Lab/Qculus store: `false`
- The app is installed via App Lab but the AppID wasn't provided in oculus platform settings: `false`
- The app is installed via App Lab and the AppID was provided: `true`

![image](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/96a186a3-72dd-4c60-89e5-3f17d0fac361)

Example sessions: https://app.cognitive3d.com/scenes/21320868-08d9-4ead-92ad-131caf9944c4/v/1/insights

Height Task ID(s) (If applicable): https://c3d.height.app/T-5631

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
