### PR TITLE
Fix to meta component checkbox state

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -43,13 +43,18 @@ namespace Cognitive3D
             // Get the current state of these components: are they already enabled?
             // This is so the checkbox can accurately display the status of the components instead of defaulting to false
             OVRManager ovrManager = Object.FindObjectOfType<OVRManager>();
-            var fi = typeof(OVRManager).GetField("requestEyeTrackingPermissionOnStartup", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-            var requestingEyeTracking = fi.GetValue(ovrManager);
-            fi = typeof(OVRManager).GetField("requestFaceTrackingPermissionOnStartup", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-            var requestingFaceTracking = fi.GetValue(ovrManager);
-            var faceExpressions = FindObjectOfType<OVRFaceExpressions>();
-
-            wantEyeTrackingEnabled = (bool) requestingEyeTracking && (bool) requestingFaceTracking && faceExpressions;
+            if (ovrManager != null )
+            {
+                var fi = typeof(OVRManager).GetField("requestEyeTrackingPermissionOnStartup", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                var requestingEyeTracking = fi.GetValue(ovrManager);
+                fi = typeof(OVRManager).GetField("requestFaceTrackingPermissionOnStartup", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                var requestingFaceTracking = fi.GetValue(ovrManager);
+                var faceExpressions = FindObjectOfType<OVRFaceExpressions>();
+                if (faceExpressions != null)
+                {
+                    wantEyeTrackingEnabled = (bool) requestingEyeTracking && (bool) requestingFaceTracking && faceExpressions;
+                }
+            }
             wantPassthroughEnabled = Cognitive3D_Manager.Instance.GetComponent<OculusPassthrough>();
             wantSocialEnabled = Cognitive3D_Manager.Instance.GetComponent<OculusSocial>();
             wantHandTrackingEnabled = Cognitive3D_Manager.Instance.GetComponent<HandTracking>();


### PR DESCRIPTION
# Description

The checkbox state was always starting at `false`. It has been fixed to initialize to whe actual current state, i.e whether or not the components are actually there on `Cognitive3D_Manager`

Height Task ID(s) (If applicable): https://c3d.height.app/T-5622

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
