### PR TITLE
Consistent dynamic id using SHA 256

### DIFF
--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -3,6 +3,11 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 
+#if C3D_USE_DETERMINISTIC_DYNAMIC_ID
+    using System.Security.Cryptography;
+    using System.Text;
+#endif
+
 //container for data and simple instance implementations (enable,disable) for dynamic object
 //also includes fields for initialization
 //this would also include some nice functions for beginning/ending engagements
@@ -740,7 +745,27 @@ namespace Cognitive3D
         //set custom id if not set otherwise
         if (string.IsNullOrEmpty(CustomId))
         {
+            // This is used to create a consistent id from objects which are not in the scene
+            // Instead of GUID we are using hash so the ids are always consistent given the object name
+#if C3D_USE_DETERMINISTIC_DYNAMIC_ID
+            string input = MeshName;
+            SHA256 mySha256 = SHA256.Create();
+            byte[] myStringInBytes = mySha256.ComputeHash(Encoding.ASCII.GetBytes(input));
+            string s = "";
+            for (int i = 0; i < myStringInBytes.Length; i++)
+            {
+                s += myStringInBytes[i].ToString("x2"); // "x2" means format the byte as hexadecimal
+            }
+            s = s.Substring(0, 31); // take the first 32 characters
+
+            // format as abcdefgh-1234-5678-1234-abcdefghijkl
+            s = s.Insert(8, "-");
+            s = s.Insert(13, "-");
+            s = s.Insert(18, "-");
+            s = s.Insert(23, "-");
+#else
             string s = System.Guid.NewGuid().ToString();
+#endif
             CustomId = s;
             UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(UnityEditor.SceneManagement.EditorSceneManager.GetActiveScene());
         }

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -3,11 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
 
-#if C3D_USE_DETERMINISTIC_DYNAMIC_ID
-    using System.Security.Cryptography;
-    using System.Text;
-#endif
-
 //container for data and simple instance implementations (enable,disable) for dynamic object
 //also includes fields for initialization
 //this would also include some nice functions for beginning/ending engagements
@@ -748,8 +743,8 @@ namespace Cognitive3D
             // This is used to create a consistent id from objects which are not in the scene
             // Instead of GUID we are using hash so the ids are always consistent given the object name
 #if C3D_USE_DETERMINISTIC_DYNAMIC_ID
-            SHA256 mySha256 = SHA256.Create();
-            byte[] myStringInBytes = mySha256.ComputeHash(Encoding.ASCII.GetBytes(MeshName));
+            System.Security.Cryptography.SHA256 mySha256 = System.Security.Cryptography.SHA256.Create();
+            byte[] myStringInBytes = mySha256.ComputeHash(System.Text.Encoding.ASCII.GetBytes(MeshName));
             string s = "";
             for (int i = 0; i < myStringInBytes.Length; i++)
             {

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -748,9 +748,8 @@ namespace Cognitive3D
             // This is used to create a consistent id from objects which are not in the scene
             // Instead of GUID we are using hash so the ids are always consistent given the object name
 #if C3D_USE_DETERMINISTIC_DYNAMIC_ID
-            string input = MeshName;
             SHA256 mySha256 = SHA256.Create();
-            byte[] myStringInBytes = mySha256.ComputeHash(Encoding.ASCII.GetBytes(input));
+            byte[] myStringInBytes = mySha256.ComputeHash(Encoding.ASCII.GetBytes(MeshName));
             string s = "";
             for (int i = 0; i < myStringInBytes.Length; i++)
             {


### PR DESCRIPTION
# Description

This enables a way to have consistent custom ids for dynamic objects. Developers can enable this option by adding `C3D_USE_DETERMINISTIC_DYNAMIC_ID` in the project settings or in the Cognitive3D runtime assembly definition file.

This algorithm uses SHA-256 with the mesh name as an input. The first 32 characters of the output is taken and formatted. 

Examples of mesh names and corresponding ids:
1. `capsule` : `881df12b-68cd-344e-83f6-b83d6e0eea5`
2. `sphere:` :  `0f58b78b-c54e-0c3e-5556-8ec522fb67b`

If `C3D_USE_DETERMINISTIC_DYNAMIC_ID` not added, the custom id option will use a GUID which will be different every time.

Height Task ID(s) (If applicable): https://c3d.height.app/T-3609

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
