### PR TITLE
Scene change event refactor

### DIFF
--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -205,7 +205,7 @@ namespace Cognitive3D
                     break;
                 }
             }
-
+            
             if (TrackingScene == null)
             {
                 Util.logWarning("The scene has not been uploaded to the dashboard. The user activity will not be captured.");
@@ -389,7 +389,7 @@ namespace Cognitive3D
                 sceneList.Clear();
                 //DynamicObject.ClearObjectIds();
             }
-            
+
             // If id exist for loaded scene, set new tracking scene
             if (replacingSceneId)
             {
@@ -482,19 +482,6 @@ namespace Cognitive3D
             if (c3dscene != null && !string.IsNullOrEmpty(c3dscene.SceneId))
             {
                 return true;
-            }
-            return false;
-        }
-
-        private bool IsNextSceneValid()
-        {
-            if (sceneList.Count > 0)
-            {
-                Scene currentScene = sceneList[0];
-                if (TryGetTrackedScene(currentScene.name, out Cognitive3D_Preferences.SceneSettings c3dscene))
-                {
-                    return true;
-                }
             }
             return false;
         }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -389,10 +389,7 @@ namespace Cognitive3D
                 sceneList.Clear();
                 //DynamicObject.ClearObjectIds();
             }
-            else if(mode == LoadSceneMode.Additive)
-            {
-                Debug.Log("@@@ " + scene.name + " loaded additively!");
-            }
+            
             // If id exist for loaded scene, set new tracking scene
             if (replacingSceneId)
             {

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -434,7 +434,7 @@ namespace Cognitive3D
                 ResetCachedTrackingSpace();
                 Util.ResetLogs();
                 sceneList.Clear();
-                SceneStartTimeDic.Clear();
+                SceneStartTimeDict.Clear();
             }
 
             //send all immediately. anything on threads will be out of date when looking for what the current tracking scene is
@@ -454,7 +454,7 @@ namespace Cognitive3D
         /// registered to unity's OnSceneUnloaded callback. sends outstanding data, then removes current scene from scene list
         /// </summary>
         /// <param name="unloadingScene"></param>
-        // // This is not called for last unloaded scene
+        // This is not called for last unloaded scene
         private void SceneManager_SceneUnloaded(Scene unloadingScene)
         {
             SendSceneUnloadEvent(unloadingScene.name);
@@ -467,9 +467,9 @@ namespace Cognitive3D
             ForceWriteSessionMetadata = true;
 
             // If a scene unloads (useful in additive cases), the scene will be removed from dictionary
-            if (SceneStartTimeDic.ContainsKey(unloadingScene.name))
+            if (SceneStartTimeDict.ContainsKey(unloadingScene.name))
             {
-                SceneStartTimeDic.Remove(unloadingScene.name);
+                SceneStartTimeDict.Remove(unloadingScene.name);
             }
 
             bool unloadingSceneHasSceneId = TryGetSceneData(unloadingScene.name, out Cognitive3D_Preferences.SceneSettings c3dscene);
@@ -511,9 +511,9 @@ namespace Cognitive3D
             {
                 if (sceneName != null)
                 {
-                    if (!SceneStartTimeDic.ContainsKey(sceneName))
+                    if (!SceneStartTimeDict.ContainsKey(sceneName))
                     {
-                        SceneStartTimeDic.Add(sceneName, Time.time);
+                        SceneStartTimeDict.Add(sceneName, Time.time);
                     }
                     if (TryGetSceneData(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
@@ -543,7 +543,7 @@ namespace Cognitive3D
             {
                 if (sceneName != null)
                 {
-                    SceneStartTimeDic.TryGetValue(sceneName, out float sceneTime);
+                    SceneStartTimeDict.TryGetValue(sceneName, out float sceneTime);
                     float duration = Time.time - sceneTime;
                     if (TryGetSceneData(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
@@ -875,8 +875,10 @@ namespace Cognitive3D
         public static Cognitive3D_Preferences.SceneSettings TrackingScene { get; private set; }
         /// <summary>
         /// Records the start time of every scene loaded, not just C3D scenes
+        /// key: scene name
+        /// value: timestamp when scene loaded
         /// </summary>
-        private static Dictionary<string,float> SceneStartTimeDic = new Dictionary<string, float>();
+        private static Dictionary<string,float> SceneStartTimeDict = new Dictionary<string, float>();
         internal static bool ForceWriteSessionMetadata = false;
 
         /// <summary>

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -394,12 +394,13 @@ namespace Cognitive3D
                 sceneList.Clear();
                 SceneStartTimeDic.Clear();
             }
+
+            //send all immediately. anything on threads will be out of date when looking for what the current tracking scene is
+            FlushData();
                
             // If id exist for loaded scene, set new tracking scene
             if (loadingSceneHasSceneId)
             {
-                //send all immediately. anything on threads will be out of date when looking for what the current tracking scene is
-                FlushData();
                 sceneList.Insert(0, loadingScene);
                 SetTrackingScene(loadingScene.name);
             }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -382,7 +382,7 @@ namespace Cognitive3D
         // This is not called for first loaded scene
         private void SceneManager_SceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            SendSceneLoadEvent(scene.name);
+            SendSceneLoadEvent(scene.name, mode);
             bool replacingSceneId = TryGetTrackedScene(scene.name, out Cognitive3D_Preferences.SceneSettings c3dscene);
 
             if (mode == LoadSceneMode.Single)
@@ -429,7 +429,7 @@ namespace Cognitive3D
         /// <summary>
         /// Sends load scene events when a new scene is loaded
         /// </summary>
-        private void SendSceneLoadEvent(string sceneName)
+        private void SendSceneLoadEvent(string sceneName, LoadSceneMode mode)
         {
             if (IsInitialized)
             {
@@ -438,11 +438,11 @@ namespace Cognitive3D
                     SceneStartTimeDic.Add(sceneName, Time.time);
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Event", "Load").SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Load Mode", mode).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
                     }
                     else
                     {                  
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Event", "Load").SetProperty("Scene Name", sceneName).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Load Mode", mode).SetProperty("Scene Name", sceneName).Send();
                     }
                 }
             }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -438,11 +438,11 @@ namespace Cognitive3D
                     SceneStartTimeDic.Add(sceneName, Time.time);
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Load Mode", mode).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
                     }
                     else
                     {                  
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Load Mode", mode).SetProperty("Scene Name", sceneName).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", sceneName).Send();
                     }
                 }
             }
@@ -461,11 +461,11 @@ namespace Cognitive3D
                     float duration = Time.time - sceneTime;
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
-                        new CustomEvent("c3d.SceneUnload").SetProperty("Duration", duration).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
+                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
                     }
                     else
                     {
-                        new CustomEvent("c3d.SceneUnload").SetProperty("Duration", duration).SetProperty("Scene Name", sceneName).Send();
+                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", sceneName).Send();
                     }
                 }
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -382,14 +382,15 @@ namespace Cognitive3D
         // This is not called for first loaded scene
         private void SceneManager_SceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            SendSceneLoadEvent(scene.name, true);
+            SendSceneLoadEvent(scene.name);
             bool replacingSceneId = TryGetTrackedScene(scene.name, out Cognitive3D_Preferences.SceneSettings c3dscene);
+
             if (mode == LoadSceneMode.Single)
             {
                 sceneList.Clear();
                 //DynamicObject.ClearObjectIds();
             }
-
+               
             // If id exist for loaded scene, set new tracking scene
             if (replacingSceneId)
             {
@@ -409,7 +410,7 @@ namespace Cognitive3D
         // // This is not called for first loaded scene
         private void SceneManager_SceneUnloaded(Scene scene)
         {
-            SendSceneUnloadEvent(scene.name, true);
+            SendSceneUnloadEvent(scene.name);
 
             if (TryGetTrackedScene(scene.name, out Cognitive3D_Preferences.SceneSettings c3dscene))
             {
@@ -421,11 +422,11 @@ namespace Cognitive3D
         /// <summary>
         /// Sends load scene events when a new scene is loaded
         /// </summary>
-        private void SendSceneLoadEvent(string sceneName, bool writeEvent)
+        private void SendSceneLoadEvent(string sceneName)
         {
             if (IsInitialized)
             {
-                if (writeEvent && sceneName != null)
+                if (sceneName != null)
                 {
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
@@ -444,11 +445,11 @@ namespace Cognitive3D
         /// <summary>
         /// Sends unload scene events when a scene is unloaded
         /// </summary>
-        private void SendSceneUnloadEvent(string sceneName, bool writeEvent)
+        private void SendSceneUnloadEvent(string sceneName)
         {
             if (IsInitialized)
             {
-                if (writeEvent && sceneName != null)
+                if (sceneName != null)
                 {
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
@@ -465,7 +466,7 @@ namespace Cognitive3D
                 }
 
                 // Flush recorded data when scene unloads
-                if (writeEvent && TrackingScene != null)
+                if (TrackingScene != null)
                 {
                     FlushData();
                 }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -376,8 +376,6 @@ namespace Cognitive3D
             #endregion
         }
 
-        bool sendLastSceneEventComplete;
-
 
         /// <summary>
         /// registered to unity's OnSceneLoaded callback. sends outstanding data, then sets correct tracking scene id and refreshes dynamic object session manifest
@@ -448,7 +446,7 @@ namespace Cognitive3D
         // Waits for scene events to be fully processed before unloading the active scene
         private IEnumerator WaitForSceneEventComplete()
         {
-            yield return new WaitUntil(() => sendLastSceneEventComplete); // Wait until scene loaded completes
+            yield return new WaitForEndOfFrame(); // Wait until the end of frame
 
             //use the top scene from the scene list
             if (sceneList.Count > 0)
@@ -459,8 +457,6 @@ namespace Cognitive3D
             {
                 TrackingScene = null;
             }
-
-            sendLastSceneEventComplete = false;
         }
 
         /// <summary>
@@ -493,8 +489,6 @@ namespace Cognitive3D
                     }
                 }
             }
-
-            sendLastSceneEventComplete = true;
         }
 
         /// <summary>

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -438,11 +438,11 @@ namespace Cognitive3D
                     SceneStartTimeDic.Add(sceneName, Time.time);
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send(Vector3.zero);
                     }
                     else
                     {                  
-                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", sceneName).Send();
+                        new CustomEvent("c3d.SceneLoad").SetProperty("Scene Load Mode", mode).SetProperty("Scene Name", sceneName).Send(Vector3.zero);
                     }
                 }
             }
@@ -461,11 +461,11 @@ namespace Cognitive3D
                     float duration = Time.time - sceneTime;
                     if (TryGetTrackedScene(sceneName, out Cognitive3D_Preferences.SceneSettings c3dscene))
                     {
-                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send();
+                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", c3dscene.SceneName).SetProperty("Scene Id", c3dscene.SceneId).Send(Vector3.zero);
                     }
                     else
                     {
-                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", sceneName).Send();
+                        new CustomEvent("c3d.SceneUnload").SetProperty("Scene Duration", duration).SetProperty("Scene Name", sceneName).Send(Vector3.zero);
                     }
                 }
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -376,6 +376,8 @@ namespace Cognitive3D
             #endregion
         }
 
+        bool sendLastSceneEventComplete;
+
 
         /// <summary>
         /// registered to unity's OnSceneLoaded callback. sends outstanding data, then sets correct tracking scene id and refreshes dynamic object session manifest
@@ -439,16 +441,26 @@ namespace Cognitive3D
             //unloading the active scene
             if (TrackingScene != null && c3dscene == TrackingScene)
             {
-                //use the top scene from the scene list
-                if (sceneList.Count > 0)
-                {
-                    SetTrackingScene(sceneList[0].name);
-                }
-                else
-                {
-                    TrackingScene = null;
-                }
+                StartCoroutine(WaitForSceneEventComplete());
             }
+        }
+
+        // Waits for scene events to be fully processed before unloading the active scene
+        private IEnumerator WaitForSceneEventComplete()
+        {
+            yield return new WaitUntil(() => sendLastSceneEventComplete); // Wait until scene loaded completes
+
+            //use the top scene from the scene list
+            if (sceneList.Count > 0)
+            {
+                SetTrackingScene(sceneList[0].name);
+            }
+            else
+            {
+                TrackingScene = null;
+            }
+
+            sendLastSceneEventComplete = false;
         }
 
         /// <summary>
@@ -458,7 +470,7 @@ namespace Cognitive3D
         {
             if (IsInitialized)
             {
-                if (!string.IsNullOrEmpty(sceneName))
+                if (sceneName != null)
                 {
                     if (!SceneStartTimeDic.ContainsKey(sceneName))
                     {
@@ -481,6 +493,8 @@ namespace Cognitive3D
                     }
                 }
             }
+
+            sendLastSceneEventComplete = true;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

The following describes changes made in Cognitive3D_Manager.cs for scene changing events:

- Removed `IsNextSceneValid()` and `DoesSceneHaveID()`
- Added `TryGetTrackedScene()` to check the scene in C3D scene settings
- Turned `SetTrackingScene()` methods into a single method and it only handles setting the tracking scene if it exist in C3D scene settings
- Added `SendSceneUnloadEvent()` and `SendSceneLoadEvent()` to handle scene change events
- Replacing `sceneStartTime` variable with `sceneStartTimeDic` dictionary. This was implemented for additive scene cases where `sceneStartTime` was getting repopulated when a new additive scene got loaded.
- Replaced `CustomEvent.Send(`) with `CustomEvent.Send(vector3 position)` for load and unload events. This will fix "No HMD found" error between scene changes.
- Modified the logic to unload the active scene when last scene event is sent before setting `trackingScene` to null or next tracked scene

Height Task ID(s) (If applicable): https://c3d.height.app/T-5781 and https://c3d.height.app/T-5121

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
