### PR TITLE
Quest Pro Eyetracking Fix

### DIFF
--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -229,20 +229,37 @@ namespace Cognitive3D
 #if C3D_OCULUS
             //eye tracking can be enabled successfully here, but there is a delay when calling OVRPlugin.eyeTrackingEnabled
             //this is used for adding the fixation recorder
+            GameplayReferences.EyeTrackingEnabled = false;
             if (GameplayReferences.SDKSupportsEyeTracking)
             {
-                var startEyeTrackingResult = OVRPlugin.StartEyeTracking();
-                var faceTrackingResult = OVRPlugin.StartFaceTracking();
+                //check permissions
+                bool eyePermissionGranted = false;
+                bool facePermissionGranted = false;
 
-                if (startEyeTrackingResult && faceTrackingResult)
+                string FaceTrackingPermission = "com.oculus.permission.FACE_TRACKING";
+                string EyeTrackingPermission = "com.oculus.permission.EYE_TRACKING";
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+                eyePermissionGranted = UnityEngine.Android.Permission.HasUserAuthorizedPermission(EyeTrackingPermission);
+                facePermissionGranted = UnityEngine.Android.Permission.HasUserAuthorizedPermission(FaceTrackingPermission);
+#endif
+                if (eyePermissionGranted && facePermissionGranted)
                 {
-                    //everything will be supported and enabled for the fixation recorder
-                    fixationRecorder = gameObject.GetComponent<FixationRecorder>();
-                    if (fixationRecorder == null)
+                    //these return true even if they're already started elsewhere
+                    var startEyeTrackingResult = OVRPlugin.StartEyeTracking();
+                    var faceTrackingResult = OVRPlugin.StartFaceTracking();
+
+                    if (startEyeTrackingResult && faceTrackingResult)
                     {
-                        fixationRecorder = gameObject.AddComponent<FixationRecorder>();
+                        GameplayReferences.EyeTrackingEnabled = true;
+                        //everything will be supported and enabled for the fixation recorder
+                        fixationRecorder = gameObject.GetComponent<FixationRecorder>();
+                        if (fixationRecorder == null)
+                        {
+                            fixationRecorder = gameObject.AddComponent<FixationRecorder>();
+                        }
+                        fixationRecorder.Initialize();
                     }
-                    fixationRecorder.Initialize();
                 }
             }
 #else

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -226,6 +226,26 @@ namespace Cognitive3D
             }
             gazeBase.Initialize();
 
+#if C3D_OCULUS
+            //eye tracking can be enabled successfully here, but there is a delay when calling OVRPlugin.eyeTrackingEnabled
+            //this is used for adding the fixation recorder
+            if (GameplayReferences.SDKSupportsEyeTracking)
+            {
+                var startEyeTrackingResult = OVRPlugin.StartEyeTracking();
+                var faceTrackingResult = OVRPlugin.StartFaceTracking();
+
+                if (startEyeTrackingResult && faceTrackingResult)
+                {
+                    //everything will be supported and enabled for the fixation recorder
+                    fixationRecorder = gameObject.GetComponent<FixationRecorder>();
+                    if (fixationRecorder == null)
+                    {
+                        fixationRecorder = gameObject.AddComponent<FixationRecorder>();
+                    }
+                    fixationRecorder.Initialize();
+                }
+            }
+#else
             if (GameplayReferences.SDKSupportsEyeTracking)
             {
                 fixationRecorder = gameObject.GetComponent<FixationRecorder>();
@@ -235,6 +255,7 @@ namespace Cognitive3D
                 }
                 fixationRecorder.Initialize();
             }
+#endif
 
             try
             {

--- a/Runtime/Scripts/FixationRecorder.cs
+++ b/Runtime/Scripts/FixationRecorder.cs
@@ -658,8 +658,6 @@ namespace Cognitive3D
         }
 #elif C3D_OCULUS
 
-        OVRFaceExpressions cachedFaceExpressions;
-
         const int CachedEyeCaptures = 30;
         private static OVRPlugin.EyeGazesState _currentEyeGazesState;
         readonly float ConfidenceThreshold = 0.5f;
@@ -671,19 +669,11 @@ namespace Cognitive3D
 
             //EyeGazeState confidence always returns 1 from OVRPlugin. this is possibly a bug and may change in future release
             //use blink expression weight for now to throw out unconfident data
-            if (cachedFaceExpressions == null)
-            {
-                cachedFaceExpressions = FindObjectOfType<OVRFaceExpressions>();
-                if (cachedFaceExpressions == null)
-                {
-                    return false;
-                }
-            }
 
             float lblinkweight;
             float rblinkweight;
-            cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
-            cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
+            GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
+            GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
 
             var eyeGazeRight = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Right];
             var eyeGazeLeft = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Left];
@@ -724,17 +714,9 @@ namespace Cognitive3D
         {
             if (!OVRPlugin.GetEyeGazesState(OVRPlugin.Step.Render, -1, ref _currentEyeGazesState))
                 return false;
-            if (cachedFaceExpressions == null)
-            {
-                cachedFaceExpressions = FindObjectOfType<OVRFaceExpressions>();
-                if (cachedFaceExpressions == null)
-                {
-                    return false;
-                }
-            }
-
+            
             float lblinkweight;
-            cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
+            GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
             var eyeGaze = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Left];
             if (!eyeGaze.IsValid)
                 return false;
@@ -744,16 +726,9 @@ namespace Cognitive3D
         {
             if (!OVRPlugin.GetEyeGazesState(OVRPlugin.Step.Render, -1, ref _currentEyeGazesState))
                 return false;
-            if (cachedFaceExpressions == null)
-            {
-                cachedFaceExpressions = FindObjectOfType<OVRFaceExpressions>();
-                if (cachedFaceExpressions == null)
-                {
-                    return false;
-                }
-            }
+
             float rblinkweight;
-            cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
+            GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
             var eyeGaze = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Right];
             if (!eyeGaze.IsValid)
                 return false;
@@ -946,9 +921,6 @@ namespace Cognitive3D
                 gliaBehaviour.OnEyeTracking.RemoveListener(RecordEyeTracking);
                 gliaBehaviour.OnEyeTracking.AddListener(RecordEyeTracking);
             }
-#elif C3D_OCULUS
-            OVRPlugin.StartEyeTracking();
-            OVRPlugin.StartFaceTracking();
 #endif
             Cognitive3D_Manager.OnPostSessionEnd += Cognitive3D_Manager_OnPostSessionEnd;
             IsInitialized = true;

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -34,6 +34,15 @@ namespace Cognitive3D
             }
         }
 
+        /// <summary>
+        /// returns if eye tracking and face tracking permissions have been allowed, and eye tracking has been started
+        /// </summary>
+        public static bool EyeTrackingEnabled
+        {
+            get;
+            internal set;
+        }
+
 #endif
 
         /// <summary>

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -14,6 +14,26 @@ namespace Cognitive3D
 #if C3D_OCULUS
         //face expressions is cached so it doesn't search every frame, instead just a null check. and only if eyetracking is already marked as supported
         static OVRFaceExpressions cachedOVRFaceExpressions;
+
+        /// <summary>
+        /// finds or creates an OVRFaceExpressions component. Used for detecting blinking
+        /// </summary>
+        public static OVRFaceExpressions OVRFaceExpressions
+        {
+            get
+            {
+                if (cachedOVRFaceExpressions == null)
+                {
+                    cachedOVRFaceExpressions = UnityEngine.Object.FindObjectOfType<OVRFaceExpressions>();
+                    if (cachedOVRFaceExpressions == null)
+                    {
+                        Cognitive3D_Manager.Instance.gameObject.AddComponent<OVRFaceExpressions>();
+                    }
+                }
+                return cachedOVRFaceExpressions;
+            }
+        }
+
 #endif
 
         /// <summary>
@@ -67,25 +87,17 @@ namespace Cognitive3D
                 return Wave.Essence.Eye.EyeManager.Instance.IsEyeTrackingAvailable();
 #elif C3D_OCULUS
 
-                //attempt to exit early if features nor supported/enabled
-                bool eyeTrackingSupportedAndEnabled = OVRPlugin.eyeTrackingSupported && OVRPlugin.eyeTrackingEnabled;
-                if (!eyeTrackingSupportedAndEnabled)
+                //just check if eye tracking is supported
+                //Cognitive3D_Manager tries to enable Eye/Face tracking to create the fixation recorder component
+
+                bool eyeTrackingSupported = OVRPlugin.eyeTrackingSupported;
+                if (!eyeTrackingSupported)
                 {
                     return false;
                 }
 
-                if (cachedOVRFaceExpressions == null)
-                {
-                    cachedOVRFaceExpressions = UnityEngine.Object.FindObjectOfType<OVRFaceExpressions>();
-                    if (cachedOVRFaceExpressions == null)
-                    {
-                        Cognitive3D_Manager.Instance.gameObject.AddComponent<OVRFaceExpressions>();
-                    }
-                }
-
-                //this happen after creating the face expression component. seems to return false if this feature has no users
-                bool faceTrackingSupportedAndEnabled = OVRPlugin.faceTrackingSupported && OVRPlugin.faceTrackingEnabled;
-                if (!faceTrackingSupportedAndEnabled)
+                bool faceTrackingSupported = OVRPlugin.faceTrackingSupported;
+                if (!faceTrackingSupported)
                 {
                     return false;
                 }

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -153,7 +153,6 @@ namespace Cognitive3D
             return lastDirection;
         }
 #elif C3D_OCULUS
-        static OVRFaceExpressions cachedFaceExpressions;
         static Vector3 lastDirection = Vector3.forward;
         private static OVRPlugin.EyeGazesState _currentEyeGazesState;
         private static float ConfidenceThreshold = 0.5f;
@@ -164,19 +163,10 @@ namespace Cognitive3D
                 if (!OVRPlugin.GetEyeGazesState(OVRPlugin.Step.Render, -1, ref _currentEyeGazesState))
                     return lastDirection;
 
-                if (cachedFaceExpressions == null)
-                {
-                    cachedFaceExpressions = UnityEngine.Object.FindObjectOfType<OVRFaceExpressions>();
-                    if (cachedFaceExpressions == null)
-                    {
-                        return lastDirection;
-                    }
-                }
-
                 float lblinkweight;
                 float rblinkweight;
-                cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
-                cachedFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
+                GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedL, out lblinkweight);
+                GameplayReferences.OVRFaceExpressions.TryGetFaceExpressionWeight(OVRFaceExpressions.FaceExpression.EyesClosedR, out rblinkweight);
 
                 var eyeGazeRight = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Right];
                 var eyeGazeLeft = _currentEyeGazesState.EyeGazes[(int)OVRPlugin.Eye.Left];

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -201,36 +201,7 @@ namespace Cognitive3D
             }
             else
             {
-                //copy of the last, generic eyedata/hmd forward implementation. used for oculus devices that don't support eye tracking
-                UnityEngine.XR.Eyes eyes;
-                var centereye = UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.CenterEye);
-
-                if (centereye.TryGetFeatureValue(UnityEngine.XR.CommonUsages.eyesData, out eyes))
-                {
-                    Vector3 convergancePoint;
-                    if (eyes.TryGetFixationPoint(out convergancePoint))
-                    {
-                        Vector3 leftPos = Vector3.zero;
-                        eyes.TryGetLeftEyePosition(out leftPos);
-                        Vector3 rightPos = Vector3.zero;
-                        eyes.TryGetRightEyePosition(out rightPos);
-
-                        Vector3 centerPos = (rightPos + leftPos) / 2f;
-
-                        var worldGazeDirection = (convergancePoint - centerPos).normalized;
-                        //openxr implementation returns a direction adjusted by the HMD's transform, but not by the parent transformations
-                        if (GameplayReferences.HMD.parent != null)
-                            worldGazeDirection = GameplayReferences.HMD.parent.TransformDirection(worldGazeDirection);
-                        lastDirection = worldGazeDirection;
-                        return worldGazeDirection;
-                    }
-                }
-                else //hmd doesn't have eye data (ie, eye tracking)
-                {
-                    //use center point of hmd
-                    return Cognitive3D.GameplayReferences.HMD.forward;
-                }
-                return lastDirection;
+                return Cognitive3D.GameplayReferences.HMD.forward;
             }
         }
 #else

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -158,7 +158,7 @@ namespace Cognitive3D
         private static float ConfidenceThreshold = 0.5f;
         static Vector3 GetLookDirection()
         {
-            if (GameplayReferences.SDKSupportsEyeTracking)
+            if (GameplayReferences.SDKSupportsEyeTracking && GameplayReferences.EyeTrackingEnabled)
             {
                 if (!OVRPlugin.GetEyeGazesState(OVRPlugin.Step.Render, -1, ref _currentEyeGazesState))
                     return lastDirection;

--- a/Runtime/Scripts/GazeReticle.cs
+++ b/Runtime/Scripts/GazeReticle.cs
@@ -13,6 +13,17 @@ namespace Cognitive3D
         public float Speed = 0.3f;
         public float Distance = 3;
 
+#if C3D_OCULUS
+        //Enables OVR eye tracking for testing without needing to begin a session. Cognitive3D_Manager also calls StartEyeTracking when a session begins
+        private void Start()
+        {
+            if (!OVRPlugin.StartEyeTracking())
+            {
+                Debug.LogWarning("GazeReticle Failed to start OVR eye tracking.");
+            }
+        }
+#endif
+
         void Update()
         {
             Ray ray = GazeHelper.GetCurrentWorldGazeRay();

--- a/Runtime/Scripts/GazeReticle.cs
+++ b/Runtime/Scripts/GazeReticle.cs
@@ -14,7 +14,8 @@ namespace Cognitive3D
         public float Distance = 3;
 
 #if C3D_OCULUS
-        //Enables OVR eye tracking for testing without needing to begin a session. Cognitive3D_Manager also calls StartEyeTracking when a session begins
+        //Enables OVR eye tracking for testing without needing to begin a session
+        //Cognitive3D_Manager also calls StartEyeTracking when a session begins and also handle user permissions
         private void Start()
         {
             if (!OVRPlugin.StartEyeTracking())


### PR DESCRIPTION
# Description

* Moved OVRPluign.StartEyeTracking to CognitiveVR_Manager from FixationRecorder
* Removed OVRPlugin.eyeTrackingEnabled from checking if eye tracking was enabled. This is not set immediately after calling OVRPluign.StartEyeTracking
* Check user permissions before trying to enable the eye tracking feature

Height Task ID(s) (If applicable): T-5618

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned this PR to myself in GitHub
- [ ] I have assigned and notified Reviewers for this PR
