### PR TITLE
One-time logging utility

### DIFF
--- a/Runtime/Components/HMDOrientation.cs
+++ b/Runtime/Components/HMDOrientation.cs
@@ -28,7 +28,7 @@ namespace Cognitive3D.Components
             {
                 if (GameplayReferences.HMD == null || trackingSpace == null)
                 {
-                    Debug.LogWarning("TrackingSpace and/or HMD not configured correctly. Unable to record HMD Orientation.");
+                    Util.LogOnce("TrackingSpace and/or HMD not configured correctly. Unable to record HMD Orientation.", LogType.Warning);
                     return;
                 }
                 RecordPitch();

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -203,7 +203,7 @@ namespace Cognitive3D.Components
             }
             // Unable to find boundary points - should we send an event?
             // Probably will return empty list; need to append with warning or somethings
-            Debug.LogWarning("Unable to find boundary points using XRInputSubsystem");
+            Util.LogOnce("Unable to find boundary points using XRInputSubsystem", LogType.Warning);
             return null;
 #endif
         }

--- a/Runtime/Internal/Util.cs
+++ b/Runtime/Internal/Util.cs
@@ -56,6 +56,11 @@ namespace Cognitive3D
 
         private static HashSet<string> logs = new HashSet<string>();
 
+        /// <summary>
+        /// Logs a message once, preventing duplicate logging of the same message
+        /// </summary>
+        /// <param name="message">The message to log</param>
+        /// <param name="logType">The type of log: Error, Warning, or Info</param>
         internal static void LogOnce(string msg, LogType logType)
         {
             if (!logs.Contains(msg))
@@ -76,6 +81,9 @@ namespace Cognitive3D
             }
         }
 
+        /// <summary>
+        /// Clears the logs, allowing messages to be logged again
+        /// </summary>
         internal static void ResetLogs()
         {
             logs.Clear();

--- a/Runtime/Internal/Util.cs
+++ b/Runtime/Internal/Util.cs
@@ -63,21 +63,24 @@ namespace Cognitive3D
         /// <param name="logType">The type of log: Error, Warning, or Info</param>
         internal static void LogOnce(string msg, LogType logType)
         {
-            if (!logs.Contains(msg))
-            {
-                switch(logType)
+            if (Cognitive3D_Preferences.Instance.EnableLogging)
+			{
+                if (!logs.Contains(msg))
                 {
-                    case LogType.Error:
-                        Debug.LogError(msg);
-                        break;
-                    case LogType.Warning:
-                        Debug.LogWarning(msg);
-                        break;
-                    default:
-                        Debug.Log(msg);
-                        break;
+                    switch(logType)
+                    {
+                        case LogType.Error:
+                            Debug.LogError(LOG_TAG + msg);
+                            break;
+                        case LogType.Warning:
+                            Debug.LogWarning(LOG_TAG + msg);
+                            break;
+                        default:
+                            Debug.Log(LOG_TAG + msg);
+                            break;
+                    }
+                    logs.Add(msg);
                 }
-                logs.Add(msg);
             }
         }
 

--- a/Runtime/Internal/Util.cs
+++ b/Runtime/Internal/Util.cs
@@ -54,6 +54,33 @@ namespace Cognitive3D
 			}
 		}
 
+        private static HashSet<string> logs = new HashSet<string>();
+
+        internal static void LogOnce(string msg, LogType logType)
+        {
+            if (!logs.Contains(msg))
+            {
+                switch(logType)
+                {
+                    case LogType.Error:
+                        Debug.LogError(msg);
+                        break;
+                    case LogType.Warning:
+                        Debug.LogWarning(msg);
+                        break;
+                    default:
+                        Debug.Log(msg);
+                        break;
+                }
+                logs.Add(msg);
+            }
+        }
+
+        internal static void ResetLogs()
+        {
+            logs.Clear();
+        }
+
         static DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         static double lastTime;
         static int lastFrame = -1;

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -807,6 +807,7 @@ namespace Cognitive3D
         /// </summary>
         private void ResetSessionData()
         {
+            Util.ResetLogs();
             InvokeEndSessionEvent();
             FlushData();
             CoreInterface.Reset();

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -381,6 +381,7 @@ namespace Cognitive3D
             bool replacingSceneId = DoesSceneHaveID(scene);
             if (mode == LoadSceneMode.Single)
             {
+                Util.ResetLogs();
                 sceneList.Clear();
                 //DynamicObject.ClearObjectIds();
             }


### PR DESCRIPTION
# Description

The following changes made to add a functionality and utility to display any logs once in the console to prevent overwhelming developers by repeated messages:

- Implemented `LogOnce()` with two parameters that handles logging messages only once
- Defined a hash set to track logged messages within a scene
- Reset the log hash set upon loading a new scene in single mode
- Used one-time logging in `HMDOrientation.cs` and `RoomSize.cs`

Height Task ID(s) (If applicable): https://c3d.height.app/T-5782

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
