### PR TITLE
TryGetTrackingSpace refactor

### DIFF
--- a/Runtime/Components/HMDOrientation.cs
+++ b/Runtime/Components/HMDOrientation.cs
@@ -10,13 +10,11 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/HMDOrientation")]
     public class HMDOrientation : AnalyticsComponentBase
     {
-        Transform trackingSpace;
 
         protected override void OnSessionBegin()
         {
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace);
         }
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
@@ -26,7 +24,7 @@ namespace Cognitive3D.Components
             //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()
             if (isActiveAndEnabled)
             {
-                if (GameplayReferences.HMD == null || trackingSpace == null)
+                if (GameplayReferences.HMD == null || Cognitive3D_Manager.Instance.trackingSpace == null)
                 {
                     Debug.LogWarning("TrackingSpace and/or HMD not configured correctly. Unable to record HMD Orientation.");
                     return;
@@ -49,7 +47,7 @@ namespace Cognitive3D.Components
         {
             // Start with quaternions to calculate rotation
             Quaternion hmdRotation = GameplayReferences.HMD.rotation;
-            Quaternion trackingSpaceRotation = trackingSpace.transform.rotation;
+            Quaternion trackingSpaceRotation = Cognitive3D_Manager.Instance.trackingSpace.transform.rotation;
 
             // Adjust rotations to "isolate" HMD rotation from trackingSpace rotation
             Quaternion adjustedRotation = Quaternion.Inverse(trackingSpaceRotation) * hmdRotation;
@@ -76,7 +74,7 @@ namespace Cognitive3D.Components
         {
             // Start with quaternions to calculate rotation
             Quaternion hmdRotation = GameplayReferences.HMD.rotation;
-            Quaternion trackingSpaceRotation = trackingSpace.transform.rotation;
+            Quaternion trackingSpaceRotation = Cognitive3D_Manager.Instance.trackingSpace.transform.rotation;
 
             // Adjust rotations to "isolate" HMD rotation from trackingSpace rotation
             Quaternion adjustedRotation = Quaternion.Inverse(trackingSpaceRotation) * hmdRotation;

--- a/Runtime/Components/RoomSize.cs
+++ b/Runtime/Components/RoomSize.cs
@@ -130,8 +130,8 @@ namespace Cognitive3D.Components
         /// </summary>
         void SendEventIfUserExitsBoundary()
         {
-            Transform trackingSpace = null;
-            if (Cognitive3D_Manager.Instance.TryGetTrackingSpace(out trackingSpace))
+            Transform trackingSpace = Cognitive3D_Manager.Instance.trackingSpace;
+            if (trackingSpace)
             {
                 if (previousBoundaryPoints != null && previousBoundaryPoints.Length != 0) // we want to avoid "fake exit" events if boundary points is empty array; this happens sometimes when you pause
                 {

--- a/Runtime/Components/RoomTrackingSpace.cs
+++ b/Runtime/Components/RoomTrackingSpace.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System;
+using System.Collections.Generic;
 
 /// <summary>
 /// This is meant to be an empty class so we can find it using FindObjectOfType<>
@@ -11,7 +12,8 @@ namespace Cognitive3D
     [AddComponentMenu("")]
     public class RoomTrackingSpace : MonoBehaviour
     {
-        public static event Action<Transform> TrackingSpaceChanged;
+        public static event Action<int, Transform> TrackingSpaceChanged;
+        private int trackingSpaceIndex;
         private Transform cachedTrackingSpace;
 
         /// <summary>
@@ -19,6 +21,7 @@ namespace Cognitive3D
         /// </summary>
         private void OnEnable()
         {
+            trackingSpaceIndex = Cognitive3D_Manager.Instance.trackingSpaceIndex;
             cachedTrackingSpace = transform;
 
             if (!Cognitive3D_Manager.IsInitialized)
@@ -42,7 +45,7 @@ namespace Cognitive3D
 
         private void InvokeTrackingSpaceChanged()
         {
-            TrackingSpaceChanged?.Invoke(cachedTrackingSpace);
+            TrackingSpaceChanged?.Invoke(trackingSpaceIndex, cachedTrackingSpace);
         }
     }
 }

--- a/Runtime/Components/RoomTrackingSpace.cs
+++ b/Runtime/Components/RoomTrackingSpace.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System;
 
 /// <summary>
 /// This is meant to be an empty class so we can find it using FindObjectOfType<>
@@ -10,6 +11,38 @@ namespace Cognitive3D
     [AddComponentMenu("")]
     public class RoomTrackingSpace : MonoBehaviour
     {
+        public static event Action<Transform> TrackingSpaceChanged;
+        private Transform cachedTrackingSpace;
 
+        /// <summary>
+        /// Set tracking space when the RoomTrackingSpace is enabled
+        /// </summary>
+        private void OnEnable()
+        {
+            cachedTrackingSpace = transform;
+
+            if (!Cognitive3D_Manager.IsInitialized)
+            {
+                Cognitive3D_Manager.OnSessionBegin += InvokeTrackingSpaceChanged;
+                return;
+            }
+            
+            InvokeTrackingSpaceChanged();
+        }
+
+        /// <summary>
+        /// Reset tracking space to null
+        /// </summary>
+        private void OnDisable()
+        {
+            cachedTrackingSpace = null;
+            InvokeTrackingSpaceChanged();
+            Cognitive3D_Manager.OnSessionBegin -= InvokeTrackingSpaceChanged;
+        }
+
+        private void InvokeTrackingSpaceChanged()
+        {
+            TrackingSpaceChanged?.Invoke(cachedTrackingSpace);
+        }
     }
 }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -4,7 +4,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System;
 using UnityEngine.SceneManagement;
-using System.Linq;
 #if C3D_STEAMVR2
 using Valve.VR;
 #endif
@@ -465,7 +464,7 @@ namespace Cognitive3D
             else
             {
                 // Removes the tracking space from list when it becomes disabled
-                if (cachedTrackingSpaceList.ElementAt(index))
+                if (cachedTrackingSpaceList[index] && index < cachedTrackingSpaceList.Count)
                 {
                     cachedTrackingSpaceList.RemoveAt(index);
                     --trackingSpaceIndex;

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -458,7 +458,7 @@ namespace Cognitive3D
         {
             if (newTrackingSpace)
             {
-                // RAdds the tracking space into list when it becomes enabled
+                // Adds the tracking space into list when it becomes enabled
                 cachedTrackingSpaceList.Insert(index, newTrackingSpace);
                 ++trackingSpaceIndex;
             }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -133,6 +133,7 @@ namespace Cognitive3D
             SceneManager.sceneLoaded += SceneManager_SceneLoaded;
             SceneManager.sceneUnloaded += SceneManager_SceneUnloaded;
             Application.wantsToQuit += WantsToQuit;
+            RoomTrackingSpace.TrackingSpaceChanged += UpdateTrackingSpace;
 
             //sets session properties for system hardware
             //also constructs network and local cache files/readers
@@ -429,6 +430,15 @@ namespace Cognitive3D
             }
         }
 
+        /// <summary>
+        /// Updates current tracking space to next valid tracking space if exists any
+        /// </summary>
+        /// <param name="newTrackingSpace"></param>
+        private void UpdateTrackingSpace(Transform newTrackingSpace)
+        {
+            trackingSpace = newTrackingSpace;
+        }
+
         private void SceneManager_SceneUnloaded(Scene scene)
         {
             if (DoesSceneHaveID(scene))
@@ -520,6 +530,7 @@ namespace Cognitive3D
         public void EndSession()
         {
             Application.wantsToQuit -= WantsToQuit;
+            RoomTrackingSpace.TrackingSpaceChanged -= UpdateTrackingSpace;
             if (IsInitialized)
             {
                 double playtime = Util.Timestamp(Time.frameCount) - SessionTimeStamp;

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -530,7 +530,6 @@ namespace Cognitive3D
         public void EndSession()
         {
             Application.wantsToQuit -= WantsToQuit;
-            RoomTrackingSpace.TrackingSpaceChanged -= UpdateTrackingSpace;
             if (IsInitialized)
             {
                 double playtime = Util.Timestamp(Time.frameCount) - SessionTimeStamp;
@@ -838,6 +837,7 @@ namespace Cognitive3D
 
             SceneManager.sceneLoaded -= SceneManager_SceneLoaded;
             SceneManager.sceneUnloaded -= SceneManager_SceneUnloaded;
+            RoomTrackingSpace.TrackingSpaceChanged -= UpdateTrackingSpace;
             CognitiveStatics.Reset();
         }
 


### PR DESCRIPTION
# Description

With new changes, tracking space is handled through `RoomTrackingSpace.cs` and `Cognitive3D_Manager.cs`:

- Created `cachedTrackingSpaceList` and `trackingSpaceIndex` to keep track of tracking spaces
- Implemented `UpdateTrackingSpace()` in `Cognitive3D_Manager.cs` for dynamically updating the tracking space based on the list's status
- Reset the list and index during single mode scene loading and in `ResetSessionData()`
- In `RoomTrackingSpace.cs`, each component assigned an index which will be sent with `TrackingSpaceChanged` event and 
- When a component is disabled, a null value is sent along with the component index to be removed from the list

Height Task ID(s) (If applicable): https://c3d.height.app/T-5865

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
