### PR TITLE
Fix for NullReferenceException in Oculus Hardware

### DIFF
--- a/Runtime/Components/OculusHardware.cs
+++ b/Runtime/Components/OculusHardware.cs
@@ -14,6 +14,8 @@ namespace Cognitive3D.Components
     public class OculusHardware : AnalyticsComponentBase
     {
 #if C3D_OCULUS
+        XRDisplaySubsystem currentActiveSubsystem;
+
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
@@ -26,7 +28,8 @@ namespace Cognitive3D.Components
             var wait = new WaitForSeconds(1);
             yield return wait;
 
-            if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("oculus"))
+            currentActiveSubsystem = GetActiveDisplaySubsystem();
+            if (currentActiveSubsystem != null && currentActiveSubsystem.SubsystemDescriptor.id.Contains("oculus"))
             {
                 while (Cognitive3D.Cognitive3D_Manager.IsInitialized)
                 {
@@ -34,7 +37,7 @@ namespace Cognitive3D.Components
                     RecordOculusStats();
                 }
             }
-            else if (GetActiveDisplaySubsystem().SubsystemDescriptor.id.Contains("OpenXR"))
+            else if (currentActiveSubsystem != null && currentActiveSubsystem.SubsystemDescriptor.id.Contains("OpenXR"))
             {
                 Debug.LogWarning("Oculus Hardware sensors cannot be accessed while using OpenXR plugin");
             }


### PR DESCRIPTION
# Description

- Checking if the current subsystem isn't null before checking it's id

Height Task ID(s) (If applicable): https://c3d.height.app/T-5991

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
