### PR TITLE
Version Update Window: Button to link to docs website

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -371,6 +371,7 @@ namespace Cognitive3D
 #region GUI
         public static Color GreenButton = new Color(0.4f, 1f, 0.4f);
         public static Color BlueishGrey = new Color32(0xE8, 0xEB, 0xFF, 0xFF);
+        public static Color CognitiveBlue = new Color32(98, 180, 243, 255);
 
         static GUIStyle headerStyle;
         public static GUIStyle HeaderStyle

--- a/Editor/UpdateSDKWindow.cs
+++ b/Editor/UpdateSDKWindow.cs
@@ -13,6 +13,8 @@ namespace Cognitive3D
         bool reminderSet = false;
         string sdkSummary;
 
+        private const string URL_FOR_SDK_UPDATE = "https://docs.cognitive3d.com/unity/updates/";
+
         //display window with changelog. changelog is provivded by github web response body
         public static void Init(string latestVersion, string changelog)
         {
@@ -76,13 +78,24 @@ namespace Cognitive3D
             //centered download button
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
-            GUI.color = EditorCore.GreenButton;
 #if USE_ATTRIBUTION
             if (GUILayout.Button("Update to Latest Version", GUILayout.Height(40), GUILayout.MaxWidth(300)))
             {
                 UnityEditor.PackageManager.UI.Window.Open("com.cognitive3d.c3d-sdk");
             }
 #else
+            GUI.color = EditorCore.CognitiveBlue;
+
+            if (GUILayout.Button(new GUIContent("Open Online Documentation       ", URL_FOR_SDK_UPDATE), GUILayout.Height(30), GUILayout.Width(220)))
+            {
+                Application.OpenURL(URL_FOR_SDK_UPDATE);
+            }
+            Rect onlineRectIcon = GUILayoutUtility.GetLastRect();
+            onlineRectIcon.x += 180;
+            GUI.Label(onlineRectIcon, EditorCore.ExternalIcon);
+
+            GUI.color = EditorCore.GreenButton;
+
             if (GUILayout.Button(new GUIContent("Update to Latest Version     ", "https://github.com/CognitiveVR/cvr-sdk-unity/releases"), GUILayout.Height(30), GUILayout.Width(200)))
             {
                 Application.OpenURL(CognitiveStatics.GITHUB_RELEASES);


### PR DESCRIPTION
# Description

A button in the update version window that links to the docs page. This is what it looks like.

![DocsGIF](https://github.com/CognitiveVR/cvr-sdk-unity/assets/14244062/c41acd3b-942f-4b3a-ae1e-791b4a1ed7b2)



Height Task ID(s) (If applicable): https://c3d.height.app/T-2608

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
