### PR TITLE
Adjusting framerate for ASW

### DIFF
--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -97,6 +97,7 @@ namespace Cognitive3D.Components
             // We cannot do this once and cache since this can be enabled/disabled per frame
             if (OVRManager.GetSpaceWarp())
             {
+                SensorRecorder.RecordDataPoint("c3d.app.meta.spaceWarp", 1);
                 Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.wasSpaceWarpUsed", true);
                 // If FPS is approximately half of device refresh rate (plus tolerance)
                 if (framesPerSecond <= (OVRPlugin.systemDisplayFrequency / 2) + TOLERANCE_FOR_CAPPED_FPS)
@@ -106,6 +107,7 @@ namespace Cognitive3D.Components
             }
             else
             {
+                SensorRecorder.RecordDataPoint("c3d.app.meta.spaceWarp", 0);
                 fpsMultiplier = 1;
             }
 #endif

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -28,11 +28,6 @@ namespace Cognitive3D.Components
         private int intervalFrameCount;
 
         /// <summary>
-        /// Used to detect changes for spacewarp enable/disable
-        /// </summary>
-        private bool wasSpaceWarpEnabledInLastFrame = false;
-
-        /// <summary>
         /// ASW caps framerate to half of device refresh rate
         /// We are defining a +- tolerance for the capepd framerate to allow for error etc.
         /// </summary>
@@ -104,15 +99,6 @@ namespace Cognitive3D.Components
             // We cannot do this once and cache since this can be enabled/disabled per frame
             if (OVRManager.GetSpaceWarp())
             {
-                if (!wasSpaceWarpEnabledInLastFrame)
-                {
-                    Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.wasSpaceWarpUsed", true);
-                    new CustomEvent("c3d.app.meta.toggle async space warp")
-                        .SetProperty("Enbled", true)
-                        .Send();
-                    wasSpaceWarpEnabledInLastFrame = true;
-                }
-
                 // If FPS is approximately half of device refresh rate (plus tolerance)
                 if (framesPerSecond <= (OVRPlugin.systemDisplayFrequency / 2) + TOLERANCE_FOR_CAPPED_FPS)
                 {
@@ -121,13 +107,6 @@ namespace Cognitive3D.Components
             }
             else
             {
-                if (wasSpaceWarpEnabledInLastFrame)
-                {
-                    new CustomEvent("c3d.app.meta.toggle async space warp")
-                        .SetProperty("Enabled", false)
-                        .Send();
-                    wasSpaceWarpEnabledInLastFrame = false;
-                }
                 fpsMultiplier = 1;
             }
 #endif

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -1,7 +1,5 @@
 ﻿using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
-using Cognitive3D;
 
 /// <summary>
 /// Sends Frames Per Second (FPS) as a sensor
@@ -99,6 +97,7 @@ namespace Cognitive3D.Components
             // We cannot do this once and cache since this can be enabled/disabled per frame
             if (OVRManager.GetSpaceWarp())
             {
+                Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.wasSpaceWarpUsed", true);
                 // If FPS is approximately half of device refresh rate (plus tolerance)
                 if (framesPerSecond <= (OVRPlugin.systemDisplayFrequency / 2) + TOLERANCE_FOR_CAPPED_FPS)
                 {

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -16,12 +16,21 @@ namespace Cognitive3D.Components
     public class Framerate : AnalyticsComponentBase
     {
         readonly float FramerateTrackingInterval = 1;
+
         //counts up the deltatime to determine when the interval ends
         private float currentTime;
+
         //the number of frames in the interval
         private int intervalFrameCount;
 
+        /// <summary>
+        /// ASW caps framerate to half of device refresh rate
+        /// We are defining a +- tolerance for the capepd framerate to allow for error etc.
+        /// </summary>
+        private readonly float TOLERANCE_FOR_CAPPED_FPS = 2;
+
         readonly List<float> deltaTimes = new List<float>(120);
+
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
@@ -81,10 +90,23 @@ namespace Cognitive3D.Components
             float finalLow5Percent = 1.0f / min5Percent;
             float finalLow1Percent = 1.0f / min1Percent;
 
-            SensorRecorder.RecordDataPoint("c3d.fps.avg", framesPerSecond);
-            SensorRecorder.RecordDataPoint("c3d.fps.5pl", finalLow5Percent);
-            SensorRecorder.RecordDataPoint("c3d.fps.1pl", finalLow1Percent);
+            float fpsMultiplier = 1;
+#if C3D_OCULUS
+            // We cannot do this once and cache since this can be enabled/disabled per frame
+            if (OVRManager.GetSpaceWarp())
+            {
+                Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.wasSpaceWarpUsed", true);
 
+                // If FPS is approximately half of device refresh rate (plus tolerance)
+                if (framesPerSecond <= (OVRPlugin.systemDisplayFrequency / 2) + 2)
+                {
+                    fpsMultiplier = 2;
+                }
+            }
+#endif
+            SensorRecorder.RecordDataPoint("c3d.fps.avg", framesPerSecond * fpsMultiplier);
+            SensorRecorder.RecordDataPoint("c3d.fps.5pl", finalLow5Percent * fpsMultiplier);
+            SensorRecorder.RecordDataPoint("c3d.fps.1pl", finalLow1Percent * fpsMultiplier);
             intervalFrameCount = 0;
             currentTime = 0;
             deltaTimes.Clear();

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -107,7 +107,9 @@ namespace Cognitive3D.Components
                 if (!wasSpaceWarpEnabledInLastFrame)
                 {
                     Cognitive3D_Manager.SetSessionProperty("c3d.app.meta.wasSpaceWarpUsed", true);
-                    new CustomEvent("c3d.app.meta.Application Space Warp enabled").Send();
+                    new CustomEvent("c3d.app.meta.toggle async space warp")
+                        .SetProperty("Enbled", true)
+                        .Send();
                     wasSpaceWarpEnabledInLastFrame = true;
                 }
 
@@ -121,7 +123,9 @@ namespace Cognitive3D.Components
             {
                 if (wasSpaceWarpEnabledInLastFrame)
                 {
-                    new CustomEvent("c3d.app.meta.Application Space Warp disabled").Send();
+                    new CustomEvent("c3d.app.meta.toggle async space warp")
+                        .SetProperty("Enabled", false)
+                        .Send();
                     wasSpaceWarpEnabledInLastFrame = false;
                 }
                 fpsMultiplier = 1;

--- a/Runtime/Components/Framerate.cs
+++ b/Runtime/Components/Framerate.cs
@@ -124,6 +124,7 @@ namespace Cognitive3D.Components
                     new CustomEvent("c3d.app.meta.Application Space Warp disabled").Send();
                     wasSpaceWarpEnabledInLastFrame = false;
                 }
+                fpsMultiplier = 1;
             }
 #endif
             SensorRecorder.RecordDataPoint("c3d.fps.avg", framesPerSecond * fpsMultiplier);


### PR DESCRIPTION
# Description

Because of ASW, framerate is capped at 36. This causes problems with our analytics and metrics, but doesn't cause any discomfort for user because of "synthetic frames". This change corrects our framerate data collection to account for ASW.

Details can be found on [this notion doc](https://www.notion.so/cognitive3d/Async-Space-Warp-4f9015ccf11f4ac281bdfb9649c8031a?pvs=4)

Height Task ID(s) (If applicable): https://c3d.height.app/T-6058

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
