### PR TITLE
Oculus entitlement fix

### DIFF
--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -16,7 +16,7 @@ namespace Cognitive3D.Components
         [SerializeField]
         private bool RecordOculusUserData = true;
 
-        [Tooltip("Automatically completes Entitlement Check when a new session starts")]
+        [Tooltip("Automatically completes entitlement check when a new session starts. If you disable this, please call Cognitive3D_BeginOculusEntitlementCheck within 10 seconds of launching your app.")]
         [SerializeField]
         private bool completeEntitlementCheckAutomatically = true;
 #endif
@@ -28,7 +28,7 @@ namespace Cognitive3D.Components
             if (completeEntitlementCheckAutomatically)
             {
                 string appID = GetAppIDFromConfig();
-                BeginEntitlementCheck(appID);
+                Cognitive3D_BeginOculusEntitlementCheck(appID);
             }
 #endif
         }
@@ -40,7 +40,7 @@ namespace Cognitive3D.Components
         /// Should be called within first 10 seconds of launching app
         /// </summary>
         /// <param name="appID"> The oculus appID found in your oculus dev dashboard </param>
-        public void BeginEntitlementCheck(string appID)
+        public void Cognitive3D_BeginOculusEntitlementCheck(string appID)
         {
             if (!Core.IsInitialized())
             {

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -15,13 +15,33 @@ namespace Cognitive3D.Components
         [Tooltip("Used to record user data like username, id, and display name. Sessions will be named as users' display name in the session list. Allows tracking users across different sessions.")]
         [SerializeField]
         private bool RecordOculusUserData = true;
+
+        [Tooltip("Automatically completes Entitlement Check when a new session starts")]
+        [SerializeField]
+        private bool completeEntitlementCheckAutomatically = true;
 #endif
 
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
 #if C3D_OCULUS
-            string appID = GetAppIDFromConfig();
+            if (completeEntitlementCheckAutomatically)
+            {
+                string appID = GetAppIDFromConfig();
+                BeginEntitlementCheck(appID);
+            }
+#endif
+        }
+
+#if C3D_OCULUS
+
+        /// <summary>
+        /// Completes the entitlement check and callbacks if check is success ful <br/>
+        /// Should be called within first 10 seconds of launching app
+        /// </summary>
+        /// <param name="appID"> The oculus appID found in your oculus dev dashboard </param>
+        public void BeginEntitlementCheck(string appID)
+        {
             if (!Core.IsInitialized())
             {
                 // Initialize will throw error if appid is invalid/missing
@@ -44,10 +64,7 @@ namespace Cognitive3D.Components
             {
                 Cognitive3D_Manager.SetSessionProperty("c3d.app.oculus.appid", appID);
             }
-#endif
         }
-
-#if C3D_OCULUS
 
         private static string GetAppIDFromConfig()
         {

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -16,7 +16,8 @@ namespace Cognitive3D.Components
         [SerializeField]
         private bool RecordOculusUserData = true;
 
-        [Tooltip("Automatically completes entitlement check when a new session starts. If you disable this, please call Cognitive3D_BeginOculusEntitlementCheck within 10 seconds of launching your app.")]
+        [Tooltip("Automatically completes entitlement check when a new session starts. This will also use the AppID from your platform settings. " +
+            "If you disable this option, please call Cognitive3D_BeginOculusEntitlementCheck within 10 seconds of launching your app.")]
         [SerializeField]
         private bool completeEntitlementCheckAutomatically = true;
 #endif

--- a/Runtime/Components/OculusSocial.cs
+++ b/Runtime/Components/OculusSocial.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Collections;
 
 #if C3D_OCULUS
 using Oculus.Platform;
@@ -16,32 +17,50 @@ namespace Cognitive3D.Components
         [SerializeField]
         private bool RecordOculusUserData = true;
 
-        [Tooltip("Automatically completes entitlement check when a new session starts. This will also use the AppID from your platform settings. " +
-            "If you disable this option, please call Cognitive3D_BeginOculusEntitlementCheck within 10 seconds of launching your app.")]
-        [SerializeField]
-        private bool completeEntitlementCheckAutomatically = true;
-#endif
+        public enum InitializeType
+        {
+            Automatic,
+            Delayed,
+            Manual
+        }
+        [Tooltip("The behaviour to handle getting user data from the Oculus Platform.\n- Automatic will Initialize the platform with the current Platform.AppID.\n- Delayed will wait until you've checked Entitlement yourself.\n- Manual requires calling the code to record these session properties.")]
+        public InitializeType initializeType = InitializeType.Automatic;
 
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
-#if C3D_OCULUS
-            if (completeEntitlementCheckAutomatically)
+
+            if (initializeType == InitializeType.Automatic)
             {
                 string appID = GetAppIDFromConfig();
-                Cognitive3D_BeginOculusEntitlementCheck(appID);
+                BeginOculusEntitlementCheck(appID);
             }
-#endif
+            else if (initializeType == InitializeType.Delayed)
+            {
+                //the developer is doing their own entitlement elsewhere, wait until that completes
+                StartCoroutine(WaitForInitialize());
+            }
+            else if (initializeType == InitializeType.Manual)
+            {
+                //call this code when you've initialized everything:
+                //var oculusSocial = FindObjectOfType<Cognitive3D.Components.OculusSocial>();
+                //if (oculusSocial != null) {oculusSocial.BeginOculusEntitlementCheck(Cognitive3D.Components.OculusSocial.GetAppIDFromConfig());}
+            }
         }
 
-#if C3D_OCULUS
+        IEnumerator WaitForInitialize()
+        {
+            yield return new WaitUntil(Core.IsInitialized);
+            string appID = GetAppIDFromConfig();
+            BeginOculusEntitlementCheck(appID);
+        }
 
         /// <summary>
-        /// Completes the entitlement check and callbacks if check is success ful <br/>
+        /// Completes the entitlement check and callbacks if check is successful
         /// Should be called within first 10 seconds of launching app
         /// </summary>
-        /// <param name="appID"> The oculus appID found in your oculus dev dashboard </param>
-        public void Cognitive3D_BeginOculusEntitlementCheck(string appID)
+        /// <param name="appID"> The Oculus AppID found in your Oculus dev dashboard </param>
+        public void BeginOculusEntitlementCheck(string appID)
         {
             if (!Core.IsInitialized())
             {
@@ -97,9 +116,7 @@ namespace Cognitive3D.Components
                 Users.GetLoggedInUser().OnComplete(UserCallback);
             }
         }
-#endif
 
-#if C3D_OCULUS
         /// <summary>
         /// Callback for getting details on the logged in user
         /// </summary>
@@ -128,9 +145,6 @@ namespace Cognitive3D.Components
             }
         }
 
-#endif
-
-#if C3D_OCULUS
         /// <summary>
         /// Callback to get the display name
         /// apparently a second request is required
@@ -151,19 +165,10 @@ namespace Cognitive3D.Components
                 }
             }
         }
-#endif
 
-        /// <summary>
-        /// Description to display in inspector
-        /// </summary>
-        /// <returns> A string representing the description </returns>
         public override string GetDescription()
         {
-#if C3D_OCULUS
-            return "Set a property for the user's oculus id and display name";
-#else
-            return "Oculus Social properties can only be accessed when using the Oculus Platform";
-#endif
+            return "Set a property for the user's Oculus ID and display name";
         }
 
         /// <summary>
@@ -171,11 +176,27 @@ namespace Cognitive3D.Components
         /// </summary>
         public override bool GetWarning()
         {
-#if C3D_OCULUS
             return false;
-#else
-            return true;
-#endif
         }
+
+#else //not C3D_OCULUS
+
+        /// <summary>
+        /// Description to display in inspector
+        /// </summary>
+        /// <returns> A string representing the description </returns>
+        public override string GetDescription()
+        {
+            return "Oculus Social properties can only be accessed when using the Oculus Platform";
+        }
+
+        /// <summary>
+        /// Warning for incompatible platform to display on inspector
+        /// </summary>
+        public override bool GetWarning()
+        {
+            return true;
+        }
+#endif
     }
 }


### PR DESCRIPTION
# Description

Fix for oculus entitlement so developers can choose when entitlement check happens.

Testing docs in notion: https://www.notion.so/cognitive3d/Oculus-Social-Testing-delayed-entitlement-check-07b8d27ffbdd4db0a5311a3eefd7ce51?pvs=4

Height Task ID(s) (If applicable): https://c3d.height.app/T-6191

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
