### PR TITLE
Fix for project validation OpenXR tracking origin bug

### DIFF
--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -249,19 +249,23 @@ namespace Cognitive3D
                     fixmessage: "Tracking origin is set to floor",
                     checkAction: () =>
                     {
+                        ProjectValidation.FindComponentInActiveScene<XROrigin>(out var xrorigins);
                         if (xrorigins != null && xrorigins.Count != 0)
                         {
-                            if (xrorigins[0].RequestedTrackingOriginMode != XROrigin.TrackingOriginMode.Floor || xrorigins[0].CurrentTrackingOriginMode != UnityEngine.XR.TrackingOriginModeFlags.Floor)
+                            if (xrorigins[0].RequestedTrackingOriginMode != XROrigin.TrackingOriginMode.Floor)
                             {
                                 return false;
                             }
-                            return true;
                         }
                         return true;
                     },
                     fixAction: () =>
                     {
-                        xrorigins[0].RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
+                        ProjectValidation.FindComponentInActiveScene<XROrigin>(out var xrorigins);
+                        if (xrorigins != null && xrorigins.Count != 0)
+                        {
+                            xrorigins[0].RequestedTrackingOriginMode = XROrigin.TrackingOriginMode.Floor;
+                        }
                     }
                 );
             } 
@@ -279,17 +283,24 @@ namespace Cognitive3D
                     fixmessage: "Tracking origin is set to floor",
                     checkAction: () =>
                     {
-                        if (cameraOffset[0].TrackingOriginMode != UnityEngine.XR.TrackingOriginModeFlags.Floor || cameraOffset[0].requestedTrackingMode != UnityEditor.XR.LegacyInputHelpers.UserRequestedTrackingMode.Floor)
-                        {
-                            return false;
-                        }
+                        ProjectValidation.FindComponentInActiveScene<CameraOffset>(out var cameraOffset);
 
+                        if (cameraOffset != null && cameraOffset.Count != 0)
+                        {
+                            if (cameraOffset[0].requestedTrackingMode != UnityEditor.XR.LegacyInputHelpers.UserRequestedTrackingMode.Floor)
+                            {
+                                return false;
+                            }
+                        }
                         return true;
                     },
                     fixAction: () =>
                     {
-                        cameraOffset[0].TrackingOriginMode = UnityEngine.XR.TrackingOriginModeFlags.Floor;
-                        cameraOffset[0].requestedTrackingMode = UnityEditor.XR.LegacyInputHelpers.UserRequestedTrackingMode.Floor;
+                        ProjectValidation.FindComponentInActiveScene<CameraOffset>(out var cameraOffset);
+                        if (cameraOffset != null && cameraOffset.Count != 0)
+                        {
+                            cameraOffset[0].requestedTrackingMode = UnityEditor.XR.LegacyInputHelpers.UserRequestedTrackingMode.Floor;
+                        }
                     }
                 );
             }


### PR DESCRIPTION
# Description

The following changes are made to fix the bug:

- improved the handling of `XROrigin` and `CameraOffset `components in both `checkAction` and `fixAction` to prevent their values from resetting when entering and exiting play mode.
- Improved checks for null values
- Removed `xrorigins[0].CurrentTrackingOriginMode` in the condition, as it consistently returns `Unknown` value
- Refined `checkAction` to focus solely on verifying if the tracking origin is set to Floor in the associated component's dropdown

Height Task ID(s) (If applicable): https://c3d.height.app/T-6690

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
