### PR TITLE
Auto assign room tracking

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -453,15 +453,15 @@ namespace Cognitive3D
                 if (xrRigOffset != null)
                 {
                     trackingSpace = xrRigOffset.gameObject;
-                    if (leftcontroller == null)
-                    {
-                        leftcontroller = xrRigOffset.Find("Left Controller").gameObject;
-                    }
-                    if (rightcontroller == null)
-                    {
-                        rightcontroller = xrRigOffset.Find("Right Controller").gameObject;
-                    }
                 }
+            }
+            if (leftcontroller == null)
+            {
+                leftcontroller = GameObject.Find("Left Controller").gameObject;
+            }
+            if (rightcontroller == null)
+            {
+                rightcontroller = GameObject.Find("Right Controller").gameObject;
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -342,6 +342,17 @@ namespace Cognitive3D
             {
                 leftcontroller = player.hands[0].gameObject;
                 rightcontroller = player.hands[1].gameObject;
+                trackingSpace = player.trackingOriginTransform.gameObject; 
+            }
+            else
+            {
+                var playArea = FindObjectOfType<SteamVR_PlayArea>();
+                if (playArea != null)
+                {
+                    leftcontroller = playArea.gameObject.transform.Find("Controller (left)").gameObject;
+                    rightcontroller = playArea.gameObject.transform.Find("Controller (right)").gameObject;
+                    trackingSpace = playArea.gameObject;
+                }
             }
 #elif C3D_OCULUS
             //basic setup

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -4,6 +4,9 @@ using UnityEditor;
 using Cognitive3D.Components;
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
 using Unity.XR.CoreUtils;
+#if C3D_VIVEWAVE
+using Wave.Essence;
+#endif
 #endif
 #if COGNITIVE3D_INCLUDE_LEGACYINPUTHELPERS
 using UnityEditor.XR.LegacyInputHelpers;
@@ -391,6 +394,14 @@ namespace Cognitive3D
 
 #elif C3D_VIVEWAVE
             //TODO investigate if automatically detecting vive wave controllers is possible
+            if (trackingSpace == null)
+            {
+                var waveRig = FindObjectOfType<WaveRig>();
+                if (waveRig != null)
+                {
+                    trackingSpace = waveRig.CameraOffset;
+                }
+            }
 #elif C3D_PICOVR
             //basic setup
             var manager = FindObjectOfType<Pvr_Controller>();

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -2,15 +2,19 @@
 using UnityEngine;
 using UnityEditor;
 using Cognitive3D.Components;
+
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
 using Unity.XR.CoreUtils;
+#endif
+
 #if C3D_VIVEWAVE
 using Wave.Essence;
 #endif
-#endif
+
 #if COGNITIVE3D_INCLUDE_LEGACYINPUTHELPERS
 using UnityEditor.XR.LegacyInputHelpers;
 #endif
+
 #if PHOTON_UNITY_NETWORKING
 using Photon.Pun;
 #endif

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -457,11 +457,11 @@ namespace Cognitive3D
             }
             if (leftcontroller == null)
             {
-                leftcontroller = GameObject.Find("Left Controller").gameObject;
+                leftcontroller = GameObject.Find("Left Controller")?.gameObject;
             }
             if (rightcontroller == null)
             {
-                rightcontroller = GameObject.Find("Right Controller").gameObject;
+                rightcontroller = GameObject.Find("Right Controller")?.gameObject;
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -695,7 +695,7 @@ namespace Cognitive3D
                 }
             }
 
-            if (GUI.Button(new Rect(160, 430, 200, 30), new GUIContent("Setup GameObjects","Setup the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
+            if (GUI.Button(new Rect(160, 420, 200, 30), new GUIContent("Set up GameObjects","Set up the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
             {
                 SetupControllers(leftcontroller, rightcontroller);
                 if (trackingSpace != null && trackingSpace.GetComponent<RoomTrackingSpace>() == null)
@@ -709,17 +709,17 @@ namespace Cognitive3D
 
             if (AllSetupComplete)
             {
-                GUI.Label(new Rect(130, 430, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 420, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(128, 430, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 420, 32, 32), EditorCore.Alert, "image_centered");
             }
 #if C3D_STEAMVR2
 
             //generate default input file if it doesn't already exist
             bool hasInputActionFile = SteamVR_Input.DoesActionsFileExist();
-            if (GUI.Button(new Rect(160, 465, 200, 30), "Append Input Bindings"))
+            if (GUI.Button(new Rect(160, 455, 200, 30), "Append Input Bindings"))
             {
                 if (SteamVR_Input.actionFile == null)
                 {
@@ -743,11 +743,11 @@ namespace Cognitive3D
             }
             if (DoesC3DInputActionSetExist())
             {
-                GUI.Label(new Rect(130, 465, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 455, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(128, 465, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 455, 32, 32), EditorCore.Alert, "image_centered");
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -443,7 +443,7 @@ namespace Cognitive3D
             if (cameraOffset != null)
             {
                 trackingSpace = cameraOffset.gameObject;
-                var cameraOffsetObject = trackingSpace.transform.Find("Camera Offset");
+                var cameraOffsetObject = cameraOffset.cameraFloorOffsetObject;
                 if (cameraOffsetObject != null)
                 {
                     trackingSpace = cameraOffsetObject.gameObject;
@@ -460,7 +460,7 @@ namespace Cognitive3D
             if (xrRig != null)
             {
                 trackingSpace = xrRig.gameObject;
-                var xrRigOffset = xrRig.transform.Find("Camera Offset");
+                var xrRigOffset = xrRig.CameraFloorOffsetObject;
                 if (xrRigOffset != null)
                 {
                     trackingSpace = xrRigOffset.gameObject;
@@ -569,7 +569,7 @@ namespace Cognitive3D
 
             //controllers
 #if C3D_STEAMVR2
-            GUI.Label(new Rect(30, 250, 440, 440), "The Controllers should have <b>SteamVR Behaviour Pose</b> components", "normallabel");
+            GUI.Label(new Rect(30, 280, 440, 440), "The Controllers should have <b>SteamVR Behaviour Pose</b> components", "normallabel");
 #else
             GUI.Label(new Rect(30, 280, 440, 440), "The Controllers may have <b>Tracked Pose Driver</b> components", "normallabel");
 #endif
@@ -719,7 +719,7 @@ namespace Cognitive3D
 
             //generate default input file if it doesn't already exist
             bool hasInputActionFile = SteamVR_Input.DoesActionsFileExist();
-            if (GUI.Button(new Rect(160, 450, 200, 30), "Append Input Bindings"))
+            if (GUI.Button(new Rect(160, 465, 200, 30), "Append Input Bindings"))
             {
                 if (SteamVR_Input.actionFile == null)
                 {
@@ -743,11 +743,11 @@ namespace Cognitive3D
             }
             if (DoesC3DInputActionSetExist())
             {
-                GUI.Label(new Rect(130, 450, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 465, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(128, 450, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 465, 32, 32), EditorCore.Alert, "image_centered");
             }
 #endif
         }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -286,6 +286,7 @@ namespace Cognitive3D
 
         [System.NonSerialized]
         bool initialPlayerSetup;
+
         //called once when entering controller update page. finds/sets expected defaults
         void PlayerSetupStart()
         {
@@ -320,9 +321,9 @@ namespace Cognitive3D
                 trackingSpace = trackingSpaceInScene.gameObject;
             }
 
-            if (leftcontroller != null && rightcontroller != null)
+            if (leftcontroller != null && rightcontroller != null && trackingSpace != null)
             {
-                //found dynamic objects for controllers - prefer to use those
+                //found dynamic objects for controllers and tracking space - prefer to use those
                 return;
             }
 
@@ -343,6 +344,7 @@ namespace Cognitive3D
             {
                 leftcontroller = manager.leftHandAnchor.gameObject;
                 rightcontroller = manager.rightHandAnchor.gameObject;
+                trackingSpace = manager.trackingSpace.gameObject;
             }
 
             OVRManager ovrManager = Object.FindObjectOfType<OVRManager>();

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -349,8 +349,18 @@ namespace Cognitive3D
                 var playArea = FindObjectOfType<SteamVR_PlayArea>();
                 if (playArea != null)
                 {
-                    leftcontroller = playArea.gameObject.transform.Find("Controller (left)").gameObject;
-                    rightcontroller = playArea.gameObject.transform.Find("Controller (right)").gameObject;
+                    var controllers = playArea.GetComponentsInChildren<SteamVR_Behaviour_Pose>();
+                    foreach (var controller in controllers)
+                    {
+                        if (controller.inputSource == SteamVR_Input_Sources.LeftHand)
+                        {
+                            leftcontroller = controller.gameObject;
+                        }
+                        if (controller.inputSource == SteamVR_Input_Sources.RightHand)
+                        {
+                            rightcontroller = controller.gameObject;
+                        }
+                    }
                     trackingSpace = playArea.gameObject;
                 }
             }
@@ -429,6 +439,11 @@ namespace Cognitive3D
                 }
             }
 #endif
+            if (leftcontroller != null && rightcontroller != null && trackingSpace != null)
+            {
+                //found controllers and tracking space from VR SDKs
+                return;
+            }
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
             var xrRig = FindObjectOfType<XROrigin>();
             if (xrRig != null)

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -484,9 +484,10 @@ namespace Cognitive3D
             PlayerSetupStart();
             GUI.Label(new Rect(30, 30, 440, 440), "You can use your existing Player Prefab. For most implementations, this is just a quick check to ensure cameras and controllers are configued correctly.", "normallabel");
             GUI.Label(new Rect(30, 100, 440, 440), "The display for the HMD should be tagged as <b>MainCamera</b>", "normallabel");
+            GUI.Label(new Rect(30, 150, 440, 440), "The <b>TrackingSpace</b> is the root transform for the HMD and controllers", "normallabel");
 
             //hmd
-            int hmdRectHeight = 150;
+            int hmdRectHeight = 200;
 
             GUI.Label(new Rect(30, hmdRectHeight, 50, 30), "HMD", "boldlabel");
             if (GUI.Button(new Rect(180, hmdRectHeight, 255, 30), mainCameraObject != null? mainCameraObject.gameObject.name:"Missing", "button_blueoutline"))
@@ -538,7 +539,7 @@ namespace Cognitive3D
 
 
             // tracking space
-            int hmdRectHeight2 = 185;
+            int hmdRectHeight2 = 235;
 
             GUI.Label(new Rect(30, hmdRectHeight2, 150, 30), "Tracking Space", "boldlabel");
             if (GUI.Button(new Rect(180, hmdRectHeight2, 255, 30), trackingSpace != null ? trackingSpace.name : "Missing", "button_blueoutline"))
@@ -570,7 +571,7 @@ namespace Cognitive3D
 #if C3D_STEAMVR2
             GUI.Label(new Rect(30, 250, 440, 440), "The Controllers should have <b>SteamVR Behaviour Pose</b> components", "normallabel");
 #else
-            GUI.Label(new Rect(30, 250, 440, 440), "The Controllers may have <b>Tracked Pose Driver</b> components", "normallabel");
+            GUI.Label(new Rect(30, 280, 440, 440), "The Controllers may have <b>Tracked Pose Driver</b> components", "normallabel");
 #endif
 
             bool leftControllerIsValid = false;
@@ -593,7 +594,7 @@ namespace Cognitive3D
                     }
                 }
             }
-            int handOffset = 290;
+            int handOffset = 320;
 
             //left hand label
             GUI.Label(new Rect(30, handOffset + 15, 150, 30), "Left Controller", "boldlabel");
@@ -694,7 +695,7 @@ namespace Cognitive3D
                 }
             }
 
-            if (GUI.Button(new Rect(160, 400, 200, 30), new GUIContent("Setup GameObjects","Setup the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
+            if (GUI.Button(new Rect(160, 430, 200, 30), new GUIContent("Setup GameObjects","Setup the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
             {
                 SetupControllers(leftcontroller, rightcontroller);
                 if (trackingSpace != null && trackingSpace.GetComponent<RoomTrackingSpace>() == null)
@@ -708,11 +709,11 @@ namespace Cognitive3D
 
             if (AllSetupComplete)
             {
-                GUI.Label(new Rect(130, 400, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                GUI.Label(new Rect(130, 430, 30, 30), EditorCore.CircleCheckmark, "image_centered");
             }
             else
             {
-                GUI.Label(new Rect(128, 400, 32, 32), EditorCore.Alert, "image_centered");
+                GUI.Label(new Rect(128, 430, 32, 32), EditorCore.Alert, "image_centered");
             }
 #if C3D_STEAMVR2
 

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -1,12 +1,15 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
 using Unity.XR.CoreUtils;
 using UnityEngine.XR;
-
 #endif
+
+#if C3D_VIVEWAVE
+using Wave.Essence;
+#endif
+
 #if COGNITIVE3D_INCLUDE_LEGACYINPUTHELPERS
 using UnityEditor.XR.LegacyInputHelpers;
 #endif
@@ -28,6 +31,8 @@ namespace Cognitive3D.Components
         private const float SAMPLE_INTERVAL = 10;
         private float[] heights;
         private Transform trackingSpace;
+        XROrigin xrOrigin = null;
+        WaveRig waveRig = null;
 
         protected override void OnSessionBegin()
         {
@@ -75,10 +80,27 @@ namespace Cognitive3D.Components
 #if C3D_OCULUS
             // Calculates height according to camera offset relative to Floor level and rig customization
             height = GameplayReferences.HMD.position.y - OVRPlugin.GetTrackingTransformRelativePose(OVRPlugin.TrackingOrigin.FloorLevel).Position.y - trackingSpace.position.y;
+#elif C3D_VIVEWAVE
+            if (waveRig == null)
+            {
+                waveRig = FindObjectOfType<WaveRig>();
+            }
+
+            if (waveRig != null)
+            {
+                if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Device)
+                {
+                    height = GameplayReferences.HMD.position.y + waveRig.CameraYOffset - trackingSpace.position.y;
+                }
+                else if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Floor)
+                {
+                    height = GameplayReferences.HMD.position.y - trackingSpace.position.y;
+                }
+            }
+
 #elif C3D_DEFAULT
 
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
-            XROrigin xrOrigin = null;
             if (xrOrigin == null)
             {
                 xrOrigin = FindObjectOfType<XROrigin>(); 

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -1,9 +1,9 @@
 ﻿using UnityEngine;
 using System.Collections;
+using UnityEngine.XR;
 
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
 using Unity.XR.CoreUtils;
-using UnityEngine.XR;
 #endif
 
 #if C3D_VIVEWAVE

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -31,8 +31,18 @@ namespace Cognitive3D.Components
         private const float SAMPLE_INTERVAL = 10;
         private float[] heights;
         private Transform trackingSpace;
+#if COGNITIVE3D_INCLUDE_COREUTILITIES
         XROrigin xrOrigin = null;
+#endif
+
+#if C3D_VIVEWAVE
         WaveRig waveRig = null;
+
+#endif
+
+#if COGNITIVE3D_INCLUDE_LEGACYINPUTHELPERS
+        CameraOffset cameraOffset = null;
+#endif
 
         protected override void OnSessionBegin()
         {
@@ -126,7 +136,6 @@ namespace Cognitive3D.Components
 #endif
 
 #if COGNITIVE3D_INCLUDE_LEGACYINPUTHELPERS
-            CameraOffset cameraOffset = null;
             if (cameraOffset == null)
             {
                 cameraOffset = FindObjectOfType<CameraOffset>();

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -92,7 +92,7 @@ namespace Cognitive3D.Components
                 {
                     height = GameplayReferences.HMD.position.y + waveRig.CameraYOffset - trackingSpace.position.y;
                 }
-                else if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Floor)
+                else if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Floor || waveRig.TrackingOrigin == TrackingOriginModeFlags.Unknown) // unknown gives incorrect values
                 {
                     height = GameplayReferences.HMD.position.y - trackingSpace.position.y;
                 }

--- a/Runtime/Components/HMDHeight.cs
+++ b/Runtime/Components/HMDHeight.cs
@@ -92,7 +92,10 @@ namespace Cognitive3D.Components
                 {
                     height = GameplayReferences.HMD.position.y + waveRig.CameraYOffset - trackingSpace.position.y;
                 }
-                else if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Floor || waveRig.TrackingOrigin == TrackingOriginModeFlags.Unknown) // unknown gives incorrect values
+                else if (waveRig.TrackingOrigin == TrackingOriginModeFlags.Floor 
+                    || waveRig.TrackingOrigin == TrackingOriginModeFlags.Unknown 
+                    || waveRig.TrackingOrigin == TrackingOriginModeFlags.TrackingReference
+                    || waveRig.TrackingOrigin == TrackingOriginModeFlags.Unbounded) // unknown and tracking gives incorrect values
                 {
                     height = GameplayReferences.HMD.position.y - trackingSpace.position.y;
                 }


### PR DESCRIPTION
# Description

Improves the scene setup window to automatically identify and assign the `TrackingSpace` object where possible. Also adds functionality to detect controllers for some setups.

Notes for testing can be found here: https://www.notion.so/cognitive3d/T-6639-UX-for-TrackingSpace-c387a3683474447594f4684b0efa867a?pvs=4

Height Task ID(s) (If applicable): https://c3d.height.app/T-6639

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
