### PR TITLE
[T-6858] Hand tracking doesn’t register dynamic object for controllers

### DIFF
--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -9,16 +9,11 @@ namespace Cognitive3D.Components
 #if C3D_OCULUS
         private GameplayReferences.TrackingType lastTrackedDevice = GameplayReferences.TrackingType.None;
 
-        protected override void OnEnable()
-        {
-            GameplayReferences.handTrackingEnabled = true; // have to do it here because doing it from scene setup doesn't work - also cannot be later than OnEnable
-        }
-
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
             lastTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
-            Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", GameplayReferences.handTrackingEnabled);
+            Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", true);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
         }

--- a/Runtime/Components/HandTracking.cs
+++ b/Runtime/Components/HandTracking.cs
@@ -9,11 +9,15 @@ namespace Cognitive3D.Components
 #if C3D_OCULUS
         private GameplayReferences.TrackingType lastTrackedDevice = GameplayReferences.TrackingType.None;
 
+        protected override void OnEnable()
+        {
+            GameplayReferences.handTrackingEnabled = true; // have to do it here because doing it from scene setup doesn't work - also cannot be later than OnEnable
+        }
+
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
             lastTrackedDevice = GameplayReferences.GetCurrentTrackedDevice();
-            GameplayReferences.handTrackingEnabled = true; // have to do it here because doing it from scene setup doesn't work
             Cognitive3D_Manager.SetSessionProperty("c3d.app.handtracking.enabled", GameplayReferences.handTrackingEnabled);
             Cognitive3D_Manager.OnUpdate += Cognitive3D_Manager_OnUpdate;
             Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -185,26 +185,28 @@ namespace Cognitive3D
             if (hasInitialized) { return; }
             StartingScale = transform.lossyScale;
             string registerMeshName = MeshName;
+            GameplayReferences.SetController(this, IsRight);
 
-            //if a controller, delay registering the controller until the controller name has returned something valid
+            // if a controller, delay registering the controller until the controller name has returned something valid
+            // if current device is hands or null, then use fallback
             if (IsController)
-            {            
+            {
                 // Special case for hand tracking (particularly when session begins with hand): 
-                    //  need this because InputDevice.isValid returns false
-                    //  and InputDevice.name gives us nothing
+                //  need this because InputDevice.isValid returns false
+                //  and InputDevice.name gives us nothing
                 if (GameplayReferences.handTrackingEnabled)
                 {
-                    // If starting with hands; use fallback controller
-                    if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand)
+                    // If starting with hands or none; use fallback controller
+                    if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand || GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.None)
                     {
                         // just quickly look up controller by type, isRight
                         SetControllerFromFallback(FallbackControllerType, IsRight);
                         registerMeshName = commonDynamicMesh.ToString();
+                        RegisterDynamicObject(registerMeshName);
                         return;
                     }
                 }
 
-                GameplayReferences.SetController(this, IsRight);
                 if (IdentifyControllerAtRuntime)
                 {
                     InputDevice device;
@@ -237,6 +239,11 @@ namespace Cognitive3D
                 }
             }
 
+            RegisterDynamicObject(registerMeshName);
+        }
+        
+        private void RegisterDynamicObject(string registerMeshName)
+        {
             if (SyncWithPlayerGazeTick)
             {
                 UpdateRate = 64;

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -185,12 +185,12 @@ namespace Cognitive3D
             if (hasInitialized) { return; }
             StartingScale = transform.lossyScale;
             string registerMeshName = MeshName;
-            GameplayReferences.SetController(this, IsRight);
 
             // if a controller, delay registering the controller until the controller name has returned something valid
             // if current device is hands or null, then use fallback
             if (IsController)
             {
+                GameplayReferences.SetController(this, IsRight);
                 // Special case for hand tracking (particularly when session begins with hand): 
                 //  need this because InputDevice.isValid returns false
                 //  and InputDevice.name gives us nothing

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -194,7 +194,7 @@ namespace Cognitive3D
                 // Special case for hand tracking (particularly when session begins with hand): 
                 //  need this because InputDevice.isValid returns false
                 //  and InputDevice.name gives us nothing
-                if (Cognitive3D_Manager.Instance.GetComponent<Cognitive3D.Components.HandTracking>());
+                if (Cognitive3D_Manager.Instance.GetComponent<Cognitive3D.Components.HandTracking>())
                 {
                     // If starting with hands or none; use fallback controller
                     if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand || GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.None)

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -194,7 +194,7 @@ namespace Cognitive3D
                 // Special case for hand tracking (particularly when session begins with hand): 
                 //  need this because InputDevice.isValid returns false
                 //  and InputDevice.name gives us nothing
-                if (GameplayReferences.handTrackingEnabled)
+                if (Cognitive3D_Manager.Instance.GetComponent<Cognitive3D.Components.HandTracking>());
                 {
                     // If starting with hands or none; use fallback controller
                     if (GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.Hand || GameplayReferences.GetCurrentTrackedDevice() == GameplayReferences.TrackingType.None)

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -10,7 +10,6 @@ namespace Cognitive3D
 {
     public static class GameplayReferences
     {
-        public static bool handTrackingEnabled;
 
 #if C3D_OCULUS
         //face expressions is cached so it doesn't search every frame, instead just a null check. and only if eyetracking is already marked as supported


### PR DESCRIPTION
# Description

Controllers weren't being added to manifest if you use only hands or none. Details can be found in the notion doc: https://www.notion.so/cognitive3d/T-6858-Hand-tracking-doesn-t-register-dynamic-object-for-controllers-62b023d1c105462592d3d548fac0e5f6?pvs=4

Height Task ID(s) (If applicable): https://c3d.height.app/T-6858

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
