### PR TITLE
Ignore item capability in project validation

### DIFF
--- a/Editor/ProjectValidation/Items/ProjectValidationItem.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItem.cs
@@ -14,8 +14,9 @@ namespace Cognitive3D
         public Func<bool> checkAction;
         public bool isFixed;
         public Action fixAction { get; }
+        public bool isIgnored;
 
-        public ProjectValidationItem(ProjectValidation.ItemLevel level, ProjectValidation.ItemCategory category, ProjectValidation.ItemAction actionType, string message, string fixmessage, Func<bool> checkAction, Action fixAction)
+        public ProjectValidationItem(ProjectValidation.ItemLevel level, ProjectValidation.ItemCategory category, ProjectValidation.ItemAction actionType, string message, string fixmessage, Func<bool> checkAction, Action fixAction, bool isIgnored)
         {
             this.level = level;
             this.category = category;
@@ -25,6 +26,7 @@ namespace Cognitive3D
             this.checkAction = checkAction;
             this.isFixed = checkAction.Invoke();
             this.fixAction = fixAction;
+            this.isIgnored = isIgnored;
 
 #if UNITY_2020_3_OR_NEWER
             var hash = new Hash128();

--- a/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
@@ -76,6 +76,14 @@ namespace Cognitive3D
             return items.Where(item => item.isIgnored == isIgnored && item.level == level);
         }
 
+        public void SetIgnoredItemsFromLog(List<string> ignoredMessages)
+        {
+            if (ignoredMessages != null && ignoredMessages.Count != 0)
+            {
+                items.ForEach(item => item.isIgnored = ignoredMessages.Contains(item.message));
+            }
+        }
+
         public List<ProjectValidationItem> GetAllItems()
         {
             return items;

--- a/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
@@ -58,12 +58,12 @@ namespace Cognitive3D
 
         public IEnumerable<ProjectValidation.ItemLevel> GetLevelsOfItemsNotFixed()
         {
-            return items.Where(item => !item.isFixed).Select(item => item.level).Distinct();
+            return items.Where(item => !item.isFixed && !item.isIgnored).Select(item => item.level).Distinct();
         }
 
         public bool hasNotFixedItems()
         {
-            return items.Where(item => item.isFixed == false).Count() != 0 ? true : false;
+            return items.Where(item => !item.isFixed && !item.isIgnored).Count() != 0 ? true : false;
         }
 
         public IEnumerable<ProjectValidationItem> GetIgnoredItems(bool isIgnored)

--- a/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
@@ -66,6 +66,16 @@ namespace Cognitive3D
             return items.Where(item => item.isFixed == false).Count() != 0 ? true : false;
         }
 
+        public IEnumerable<ProjectValidationItem> GetIgnoredItems(bool isIgnored)
+        {
+            return items.Where(item => item.isIgnored == isIgnored);
+        }
+
+        public IEnumerable<ProjectValidationItem> GetIgnoredItems(bool isIgnored, ProjectValidation.ItemLevel level)
+        {
+            return items.Where(item => item.isIgnored == isIgnored && item.level == level);
+        }
+
         public List<ProjectValidationItem> GetAllItems()
         {
             return items;

--- a/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemRegistry.cs
@@ -80,7 +80,13 @@ namespace Cognitive3D
         {
             if (ignoredMessages != null && ignoredMessages.Count != 0)
             {
-                items.ForEach(item => item.isIgnored = ignoredMessages.Contains(item.message));
+                items.ForEach(item =>
+                {
+                    if (!item.isFixed)
+                    {
+                        item.isIgnored = ignoredMessages.Contains(item.message);
+                    }
+                });
             }
         }
 

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -38,6 +38,7 @@ namespace Cognitive3D
 
             AddProjectValidationItems();
             UpdateProjectValidationItemStatus();
+            ProjectValidation.SetIgnoredItemsFromLog();
             ProjectValidationGUI.Reset();
         }
 

--- a/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
@@ -1,4 +1,5 @@
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
 using System.Collections.Generic;

--- a/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
@@ -22,16 +22,6 @@ namespace Cognitive3D
             }
         }
 
-        private static bool _displayProjectValidationPopup = true;
-        public static bool displayProjectValidationPopup {
-            get {
-                return _displayProjectValidationPopup;
-            }
-            internal set {
-                _displayProjectValidationPopup = value;
-            }
-        }
-
         static ProjectValidationItemsStatus()
         {
             EditorSceneManager.sceneOpened += OnSceneOpened;
@@ -122,7 +112,7 @@ namespace Cognitive3D
         /// </summary>
         internal static void VerifyAllBuildScenes()
         {
-            if (displayProjectValidationPopup)
+            if (ProjectValidationLog.GetBuildProcessPopup())
             {
                 // Popup
                 bool result = EditorUtility.DisplayDialog(LOG_TAG + "Build Paused", "Would you like to perform Cognitive3D project validation by verifying all build scenes? \n \nSelect \"Yes\" to verify scenes or \"No\" to continue with the build process. \n \n**Please note that if you choose to verify scenes, the build process will be stopped and will need to be restarted**", "Yes", "No");

--- a/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
@@ -116,7 +116,7 @@ namespace Cognitive3D
             if (ProjectValidationLog.GetBuildProcessPopup())
             {
                 // Popup
-                bool result = EditorUtility.DisplayDialog(LOG_TAG + "Build Paused", "Would you like to perform Cognitive3D project validation by verifying all build scenes? \n \nSelect \"Yes\" to verify scenes or \"No\" to continue with the build process. \n \n**Please note that if you choose to verify scenes, the build process will be stopped and will need to be restarted**", "Yes", "No");
+                bool result = EditorUtility.DisplayDialog(LOG_TAG + "Build Paused", "Would you like to verify that all build scenes meet the Cognitive3D configuration requirements? \n \n**Please note that if you choose to verify scenes, the build process will be stopped and will need to be restarted**", "Verify", "Skip");
                 if (result)
                 {
                     throwExecption = true;

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -58,9 +58,9 @@ namespace Cognitive3D
         /// <param name="fixmessage">Description of the fix for the item</param>
         /// <param name="isFixed">Checks if item is fixed or not</param>
         /// <param name="fixAction">Delegate that validates the item</param>
-        internal static void AddItem(ItemLevel level, ItemCategory category, ItemAction actionType, string message, string fixmessage, Func<bool> checkAction, Action fixAction = null)
+        internal static void AddItem(ItemLevel level, ItemCategory category, ItemAction actionType, string message, string fixmessage, Func<bool> checkAction, Action fixAction = null, bool isIgnored = false)
         {
-            var newItem = new ProjectValidationItem(level, category, actionType, message, fixmessage, checkAction, fixAction);
+            var newItem = new ProjectValidationItem(level, category, actionType, message, fixmessage, checkAction, fixAction, isIgnored);
             AddItem(newItem);
         }
 
@@ -70,6 +70,22 @@ namespace Cognitive3D
         internal static IEnumerable<ProjectValidationItem> GetAllItems()
         {
             return registry.GetAllItems();
+        }
+
+        // <summary>
+        /// Gets all <see cref="ProjectValidationItem"/>s are ignored or not
+        /// </summary>
+        internal static IEnumerable<ProjectValidationItem> GetIgnoredItems(bool isIgnored)
+        {
+            return registry.GetIgnoredItems(isIgnored);
+        }
+
+        // <summary>
+        /// Gets <see cref="ProjectValidationItem"/>s are ignored or not related to a level
+        /// </summary>
+        internal static IEnumerable<ProjectValidationItem> GetIgnoredItems(bool isIgnored, ItemLevel level)
+        {
+            return registry.GetIgnoredItems(isIgnored, level);
         }
 
         /// <summary>
@@ -125,6 +141,16 @@ namespace Cognitive3D
             Scene currentScene = SceneManager.GetActiveScene();
             EditorSceneManager.SaveScene(currentScene);
 
+            ProjectValidationItems.UpdateProjectValidationItemStatus();
+        }
+
+        /// <summary>
+        /// Ignores <see cref="ProjectValidationItem"/> item
+        /// </summary>
+        /// <param name="item"></param>
+        internal static void IgnoreItem(ProjectValidationItem item, bool ignoreStatus)
+        {
+            item.isIgnored = ignoreStatus;
             ProjectValidationItems.UpdateProjectValidationItemStatus();
         }
 

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -151,6 +151,15 @@ namespace Cognitive3D
         internal static void IgnoreItem(ProjectValidationItem item, bool ignoreStatus)
         {
             item.isIgnored = ignoreStatus;
+            if (ignoreStatus == true)
+            {
+                ProjectValidationLog.AddIgnoreItem(item.message);
+            }
+            else
+            {
+                ProjectValidationLog.RemoveIgnoreItem(item.message);
+            }
+            
             ProjectValidationItems.UpdateProjectValidationItemStatus();
         }
 

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -164,6 +164,14 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Sets ignored <see cref="ProjectValidationItem"/> items from log
+        /// </summary>
+        internal static void SetIgnoredItemsFromLog()
+        {
+            registry.SetIgnoredItemsFromLog(ProjectValidationLog.GetLogIgnoreItems());
+        }
+
+        /// <summary>
         /// Resets ignored <see cref="ProjectValidationItem"/> items
         /// </summary>
         internal static void ResetIgnoredItems()

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -164,6 +164,19 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Resets ignored <see cref="ProjectValidationItem"/> items
+        /// </summary>
+        internal static void ResetIgnoredItems()
+        {
+            var ignoredItems =  registry.GetIgnoredItems(true);
+
+            foreach (var item in ignoredItems)
+            {
+                item.isIgnored = false;
+            }
+        }
+
+        /// <summary>
         /// Clears <see cref="ProjectValidationItem"/> list
         /// </summary>
         internal static void Reset()

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -169,6 +169,7 @@ namespace Cognitive3D
         {
             if (state == PlayModeStateChange.EnteredEditMode)
             {
+                ProjectValidation.SetIgnoredItemsFromLog();
                 ProjectValidationItems.UpdateProjectValidationItemStatus();
                 Reset();
             }

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -228,6 +228,7 @@ namespace Cognitive3D
                     menu.AddItem(new GUIContent("Reset Ignored Items"), false, () =>
                     {
                         ProjectValidationLog.ClearIgnoreItems();
+                        ProjectValidation.ResetIgnoredItems();
                         ProjectValidationItems.UpdateProjectValidationItemStatus();
                         Reset();
                     });

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -12,7 +12,8 @@ namespace Cognitive3D
         internal class Styles
         {
             private const float SmallIconSize = 16.0f;
-            private const float FixButtonWidth = 64.0f;
+            private const float MediumButtonWidth = 64.0f;
+            private const float LargeButtonWidth = 90.0f;
             private const float IconButtonWidth = 30.0f;
             internal const float GroupSelectionWidth = 244.0f;
             internal const float LabelWidth = 96f;
@@ -59,11 +60,18 @@ namespace Cognitive3D
                 fixedHeight = SmallIconSize
             };
 
-            internal readonly GUIStyle FixButton = new GUIStyle(EditorStyles.miniButton)
+            internal readonly GUIStyle MediumButton = new GUIStyle(EditorStyles.miniButton)
             {
                 margin = new RectOffset(0, 10, 2, 2),
                 stretchWidth = false,
-                fixedWidth = FixButtonWidth,
+                fixedWidth = MediumButtonWidth,
+            };
+
+            internal readonly GUIStyle LargeButton = new GUIStyle(EditorStyles.miniButton)
+            {
+                margin = new RectOffset(0, 10, 2, 2),
+                stretchWidth = false,
+                fixedWidth = LargeButtonWidth,
             };
 
             internal readonly GUIStyle IconButton = new GUIStyle(EditorStyles.miniButton)
@@ -152,6 +160,7 @@ namespace Cognitive3D
             GenerateItemLevelList(EditorCore.Error, ProjectValidation.ItemLevel.Required);
             GenerateItemLevelList(EditorCore.Alert, ProjectValidation.ItemLevel.Recommended);
             GenerateCompletedItemList();
+            GenerateIgnoredItemList();
 
             isInitialized = true;
         }
@@ -246,9 +255,14 @@ namespace Cognitive3D
                             foreach (var item in list.items)
                             {
                                 string buttonText = item.actionType.ToString();
-                                if (list.listName != "Completed" && !item.isFixed)
+                                if ((list.listName != "Completed" || list.listName != "Ignored") && (!item.isFixed && !item.isIgnored))
                                 {
                                     DrawItem(item, list.listItemIcon, item.message, true, buttonText);
+                                }
+
+                                if (list.listName == "Ignored" && item.isIgnored)
+                                {
+                                    DrawItem(item, null, item.message, true, buttonText);
                                 }
                                 
                                 if (list.listName == "Completed" && item.isFixed)
@@ -270,15 +284,35 @@ namespace Cognitive3D
         {
             using (var scope = new EditorGUILayout.HorizontalScope(styles.ListLabel))
             {
-                GUILayout.Label(itemIcon, styles.InlinedIconStyle);
+                if (itemIcon != null)
+                {
+                    GUILayout.Label(itemIcon, styles.InlinedIconStyle);
+                }
                 GUILayout.Label(message, styles.ItemDescription);
 
-                if (item.fixAction != null)
+                if (item.fixAction != null && buttonEnabled)
                 {
-                    if (buttonEnabled && GUILayout.Button(buttonText, styles.FixButton))
+                    if (!item.isIgnored)
                     {
-                        ProjectValidation.FixItem(item);
-                        GenerateCompletedItemList();
+                        if (GUILayout.Button(buttonText, styles.MediumButton))
+                        {
+                            ProjectValidation.FixItem(item);
+                            GenerateCompletedItemList();
+                        }
+
+                        if (GUILayout.Button("Ignore", styles.MediumButton))
+                        {
+                            ProjectValidation.IgnoreItem(item, true);
+                            GenerateIgnoredItemList();
+                        }
+                    }
+                    else
+                    {
+                        if (GUILayout.Button("Don't Ignore", styles.LargeButton))
+                        {
+                            ProjectValidation.IgnoreItem(item, false);
+                            GenerateIgnoredItemList();
+                        }
                     }
                 }
             }
@@ -298,6 +332,22 @@ namespace Cognitive3D
             if (foldableList == null)
             {
                 AddToFodableList("Completed", EditorCore.CircleCheckmark, items);
+            }
+            else
+            {
+                foldableList.items = items;
+            }
+        }
+
+        private static void GenerateIgnoredItemList()
+        {
+            var foldableList = foldableLists.FirstOrDefault(list => list.listName == "Ignored");
+            var items = ProjectValidation.GetIgnoredItems(true).ToList();
+
+            if (foldableList == null)
+            {
+                // Item icon should be used!
+                AddToFodableList("Ignored", EditorCore.CircleCheckmark, items);
             }
             else
             {

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -318,7 +318,7 @@ namespace Cognitive3D
                     }
                     else
                     {
-                        if (GUILayout.Button("Don't Ignore", styles.LargeButton))
+                        if (GUILayout.Button("Revert", styles.MediumButton))
                         {
                             ProjectValidation.IgnoreItem(item, false);
                             GenerateIgnoredItemList();

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -220,8 +220,16 @@ namespace Cognitive3D
                 {
                     GenericMenu menu = new GenericMenu();
                     menu.AddItem(new GUIContent("Verify all build scenes"), false, ProjectValidationItemsStatus.StartSceneVerificationProcess);
-                    menu.AddItem(new GUIContent("Show project verification prompt before build"), ProjectValidationItemsStatus.displayProjectValidationPopup, () => {
-                        ProjectValidationItemsStatus.displayProjectValidationPopup = !ProjectValidationItemsStatus.displayProjectValidationPopup;
+                    menu.AddItem(new GUIContent("Show project verification prompt before build"), ProjectValidationLog.GetBuildProcessPopup(), () =>
+                    {
+                        var showPopup = ProjectValidationLog.GetBuildProcessPopup();
+                        ProjectValidationLog.SetBuildProcessPopup(!showPopup);
+                    });
+                    menu.AddItem(new GUIContent("Reset Ignored Items"), false, () =>
+                    {
+                        ProjectValidationLog.ClearIgnoreItems();
+                        ProjectValidationItems.UpdateProjectValidationItemStatus();
+                        Reset();
                     });
 
                     menu.ShowAsContext();

--- a/Editor/ProjectValidation/ProjectValidationLog.cs
+++ b/Editor/ProjectValidation/ProjectValidationLog.cs
@@ -64,6 +64,25 @@ namespace Cognitive3D
             File.WriteAllText(FILEPATH, JsonUtility.ToJson(pvj));
         }
 
+        public static void RemoveIgnoreItem(string itemId)
+        {
+            //file doesn't exist, create a new file
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                pvj = new ProjectValidationJSON();
+            }
+
+            //item doesn't exist
+            if (!pvj.ignoredItems.Contains(itemId)) { return; }
+
+            //remove item to ignored list
+            pvj.ignoredItems.Remove(itemId.ToString());
+
+            //write to file path
+            File.WriteAllText(FILEPATH, JsonUtility.ToJson(pvj));
+        }
+
         static bool ReadLog(out ProjectValidationJSON projectValidationLog)
         {
             if (!File.Exists(FILEPATH))

--- a/Editor/ProjectValidation/ProjectValidationLog.cs
+++ b/Editor/ProjectValidation/ProjectValidationLog.cs
@@ -76,7 +76,7 @@ namespace Cognitive3D
             //item doesn't exist
             if (!pvj.ignoredItems.Contains(itemId)) { return; }
 
-            //remove item to ignored list
+            //remove item from ignored list
             pvj.ignoredItems.Remove(itemId.ToString());
 
             //write to file path

--- a/Editor/ProjectValidation/ProjectValidationLog.cs
+++ b/Editor/ProjectValidation/ProjectValidationLog.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Cognitive3D
@@ -19,11 +20,101 @@ namespace Cognitive3D
 
             File.WriteAllText(FILEPATH, json);
         }
+
+        public static void SetBuildProcessPopup(bool showPopup)
+        {
+            //file doesn't exist, create a new file
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                pvj = new ProjectValidationJSON();
+            }
+            pvj.showBuildPopup = showPopup;
+
+            //write to file path
+            File.WriteAllText(FILEPATH, JsonUtility.ToJson(pvj));
+        }
+
+        public static bool GetBuildProcessPopup()
+        {
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                return true;
+            }
+            return pvj.showBuildPopup;
+        }
+
+        public static void AddIgnoreItem(string itemId)
+        {
+            //file doesn't exist, create a new file
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                pvj = new ProjectValidationJSON();
+            }
+
+            //item already ignored
+            if (pvj.ignoredItems.Contains(itemId)) { return; }
+
+            //add item to ignored list
+            pvj.ignoredItems.Add(itemId.ToString());
+
+            //write to file path
+            File.WriteAllText(FILEPATH, JsonUtility.ToJson(pvj));
+        }
+
+        static bool ReadLog(out ProjectValidationJSON projectValidationLog)
+        {
+            if (!File.Exists(FILEPATH))
+            {
+                projectValidationLog = null;
+                return false;
+            }
+            projectValidationLog = JsonUtility.FromJson<ProjectValidationJSON>(File.ReadAllText(FILEPATH));
+            return true;
+        }
+
+        public static List<string> GetLogIgnoreItems()
+        {
+            //file doesn't exist, return empty list
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                return new List<string>();
+            }
+            return pvj.ignoredItems;
+        }
+
+        public static bool ContainsIgnoreItem(string message)
+        {
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                return false;
+            }
+            return pvj.ignoredItems.Contains(message);
+        }
+
+        public static void ClearIgnoreItems()
+        {
+            ProjectValidationJSON pvj;
+            if (!ReadLog(out pvj))
+            {
+                return;
+            }
+            pvj.ignoredItems.Clear();
+
+            //write to file path
+            File.WriteAllText(FILEPATH, JsonUtility.ToJson(pvj));
+        }
     }
 
     [System.Serializable]
     internal class ProjectValidationJSON
     {
+        public bool showBuildPopup = true;
         public string applicationVersion;
+        public List<string> ignoredItems = new List<string>();
     }
 }


### PR DESCRIPTION
# Description

This PR introduces the "ignore" capability to project validation items:

- Added a new attribute `isIgnored` in `ProjectValidationItem.cs`
- Implemented functionality to read, write, and reset ignored items in a JSON file (Thanks to Calder!).
- Fixed the resetting issue of the "Show project validation prompt before build" option after recompilation (Thanks to Calder!).
- Enabled reading of ignored items when opening the editor or exiting play mode.
- Updated the project validation window UI to support the ignore item capability.

Height Task ID(s) (If applicable): https://c3d.height.app/T-6870

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [ ] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
