### PR TITLE
MRUK support for floor area Meta SDK >= 65

### DIFF
--- a/Editor/Cognitive3DEditor.asmdef
+++ b/Editor/Cognitive3DEditor.asmdef
@@ -22,7 +22,8 @@
         "Unity.XR.OpenXR",
         "Unity.XR.OpenXR.Features.MetaQuestSupport",
         "Unity.XR.PICO",
-        "Unity.XR.PicoXR"
+        "Unity.XR.PicoXR",
+        "meta.xr.mrutilitykit"
     ],
     "includePlatforms": [
         "Editor"
@@ -68,6 +69,11 @@
             "name": "com.meta.xr.sdk.core",
             "expression": "65.0.0",
             "define": "COGNITIVE3D_INCLUDE_META_CORE_65_OR_NEWER"
+        },
+        {
+            "name": "com.meta.xr.mrutilitykit",
+            "expression": "65.0.0",
+            "define": "COGNITIVE3D_INCLUDE_META_XR_UTILITY"
         }
     ],
     "noEngineReferences": false

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -25,6 +25,10 @@ using System.IO;
 using Valve.Newtonsoft.Json;
 #endif
 
+#if COGNITIVE3D_INCLUDE_META_XR_UTILITY
+using Meta.XR.MRUtilityKit;
+#endif
+
 //uploading multiple scenes at once?
 
 namespace Cognitive3D
@@ -41,6 +45,7 @@ namespace Cognitive3D
         const string SCENE_MANAGER_NAME = "Cognitive3D_OVRSceneManager";
         const string SCENE_PLANE_PREFAB_NAME = "Cognitive3D_PlanePrefab";
         const string SCENE_VOLUME_PREFAB_NAME = "Cognitive3D_VolumePrefab";
+        const string MRUK_NAME = "Cognitive3D_Meta_MRUK";
 #endif
 
         private const string URL_SESSION_TAGS_DOCS = "https://docs.cognitive3d.com/dashboard/organization-settings/#session-tags";
@@ -1086,6 +1091,13 @@ namespace Cognitive3D
                     // OVRSceneAnchor already has [DisallowMultipleComponent]
                     volumePrefab.AddComponent<OVRSceneAnchor>();
                     sceneManagerComponent.VolumePrefab = volumePrefab.GetComponent<OVRSceneAnchor>();
+                }
+#elif COGNITIVE3D_INCLUDE_META_XR_UTILITY
+                var mruk = FindObjectOfType<MRUK>()?.gameObject;
+                if (mruk == null)
+                {
+                    mruk = new GameObject(MRUK_NAME);
+                    mruk.AddComponent<MRUK>();
                 }
 #endif
             }

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -21,7 +21,8 @@
         "UnityEngine.XR.LegacyInputHelpers",
         "Unity.XR.PicoXR",
         "PhotonUnityNetworking",
-        "PhotonRealtime"
+        "PhotonRealtime",
+        "meta.xr.mrutilitykit"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -50,6 +51,11 @@
             "name": "com.meta.xr.sdk.core",
             "expression": "65.0.0",
             "define": "COGNITIVE3D_INCLUDE_META_CORE_65_OR_NEWER"
+        },
+        {
+            "name": "com.meta.xr.mrutilitykit",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_META_XR_UTILITY"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
+++ b/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
@@ -18,7 +18,7 @@ namespace Cognitive3D.Components
         OVRSceneManager sceneManager;
 
         private void Start()
-        {   
+        {
             sceneManager = FindObjectOfType<OVRSceneManager>();
             if (sceneManager != null )
             {

--- a/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
+++ b/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
@@ -49,6 +49,12 @@ namespace Cognitive3D.Components
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
         }
 
+        private void OnDestroy()
+        {
+            sceneManager.SceneModelLoadedSuccessfully -= SetRoomDimensionsAsSessionProperty;
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+        }
+
 #elif COGNITIVE3D_INCLUDE_META_XR_UTILITY
         MRUK mixedRealityUtility;
         private void Start()
@@ -77,8 +83,13 @@ namespace Cognitive3D.Components
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
         }
 
-#endif
+        private void OnDestroy()
+        {
+            mixedRealityUtility.SceneLoadedEvent.RemoveListener(MrukLoaded);
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+        }
 
+#endif
 
         /// <summary>
         /// Component description for the inspector

--- a/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
+++ b/Runtime/Components/Cognitive3D_MetaSceneMesh.cs
@@ -63,7 +63,6 @@ namespace Cognitive3D.Components
 
         public void MrukLoaded()
         {
-            new CustomEvent("ROOM LOADED MRUKLOADED").Send();
             float width =  mixedRealityUtility.GetCurrentRoom().FloorAnchor.PlaneRect.Value.width;
             float height = mixedRealityUtility.GetCurrentRoom().FloorAnchor.PlaneRect.Value.height;
             Cognitive3D_Manager.SetSessionProperty("c3d.physicalRoom.width", width);


### PR DESCRIPTION
# Description

Meta SDK version >= 65 does not support `OVRSceneManager` - it uses `MRUK`. This PR adds support for `MRUK`.
Tested functionality - it works.

Height Task ID(s) (If applicable):

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [ ] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
