### PR TITLE
User inactivity popup update

### DIFF
--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -167,27 +167,12 @@ namespace Cognitive3D
         /// TODO: Need support for other SDKs
         private static bool IsUserPresent()
         {
-#if C3D_OCULUS
-            bool isPresent;
-            InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
-            currentHmd.TryGetFeatureValue(CommonUsages.userPresence, out isPresent);
-            return isPresent;
-#elif C3D_DEFAULT
-            Vector3 velocity;
-            InputDevice currentHmd = InputDevices.GetDeviceAtXRNode(XRNode.Head);
-
-            currentHmd.TryGetFeatureValue(CommonUsages.deviceVelocity, out velocity);
-
-            if (velocity != Vector3.zero)
-            {
-                return true;
-            }
-            else
+            if (GameplayReferences.HMD == null)
             {
                 return false;
             }
-#else
-            if (Vector3.Distance(GameplayReferences.HMD.position,lastPosition) < 0.01f) //distance hasn't changed much since last check
+
+            if (Vector3.Distance(GameplayReferences.HMD.position, lastPosition) < 0.01) // Distance hasn't changed much since last check
             {
                 return false;
             }
@@ -196,7 +181,6 @@ namespace Cognitive3D
                 lastPosition = GameplayReferences.HMD.position;
                 return true;
             }
-#endif
         }
 
         private void OnGUI()

--- a/Editor/EditorUtils.cs
+++ b/Editor/EditorUtils.cs
@@ -164,7 +164,6 @@ namespace Cognitive3D
         /// <summary>
         /// Checks whether the headset is currently worn by the user in Editor
         /// </summary>
-        /// TODO: Need support for other SDKs
         private static bool IsUserPresent()
         {
             if (GameplayReferences.HMD == null)


### PR DESCRIPTION
# Description

The following changes are made for inactivity popup:

- Checking GameplayReference HMD movement for user inactivity (for all SDKs) which should cover all edge cases

Notion doc for tests (Testing New Inactivity Approach): https://www.notion.so/cognitive3d/User-Inactivity-Popup-17d3827d61fc42948aff140efd67b3ef

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [N/A] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
