### PR TITLE
Project Validation: Check Number of Controllers in Scene

### DIFF
--- a/Editor/ProjectValidation/Items/ProjectValidationItem.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItem.cs
@@ -9,7 +9,7 @@ namespace Cognitive3D
         public ProjectValidation.ItemLevel level { get; }
         public ProjectValidation.ItemCategory category { get; }
         public ProjectValidation.ItemAction actionType {get;}
-        public string message { get; }
+        public string message { get; set; }
         public string fixmessage { get; }
         public Func<bool> checkAction;
         public bool isFixed;

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -189,13 +189,13 @@ namespace Cognitive3D
                 level: ProjectValidation.ItemLevel.Required, 
                 category: CATEGORY,
                 actionType: ProjectValidation.ItemAction.None,
-                message : "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers." + (TryGetControllers(out var controllerNamesList) ? $" The detected controller objects: {string.Join(", ", controllerNamesList)}" : ""),
+                message : "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers. Remove any additional controller dynamic objects." + (TryGetControllers(out var controllerNamesList) ? $" The detected controller objects: {string.Join(", ", controllerNamesList)}" : ""),
                 fixmessage: "2 Controllers detected in scene.",
                 checkAction: () =>
                 {
                     ProjectValidation.FindComponentInActiveScene<DynamicObject>(out var _controllers);
 
-                    string newmessage = "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers." + (TryGetControllers(out var controllerNamesList) ? $" The detected controller objects: {string.Join(", ", controllerNamesList)}" : "");
+                    string newmessage = "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers. Remove any additional controller dynamic objects." + (TryGetControllers(out var controllerNamesList) ? $" The detected controller objects: {string.Join(", ", controllerNamesList)}" : "");
 
                     UpdateProjectValidationItemMessage("More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers.", newmessage);
                     

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -195,7 +195,7 @@ namespace Cognitive3D
                 {
                     ProjectValidation.FindComponentInActiveScene<DynamicObject>(out var _controllers);
 
-                    string newmessage = "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers. Remove any additional controller dynamic objects." + (TryGetControllers(out var controllerNamesList) ? $" The detected controller objects: {string.Join(", ", controllerNamesList)}" : "");
+                    string newmessage = "More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers. Remove any additional controller dynamic objects." + (TryGetControllers(out var _controllerNamesList) ? $" The detected controller objects: {string.Join(", ", _controllerNamesList)}" : "");
 
                     UpdateProjectValidationItemMessage("More than 2 controller dynamic objects were found. Each scene should have a maximum of 2 controllers.", newmessage);
                     

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -190,7 +190,7 @@ namespace Cognitive3D
                 category: CATEGORY,
                 actionType: ProjectValidation.ItemAction.None,
                 message : "Controllers are not correctly set up.",
-                fixmessage: "The maximum limit of controllers has not been exceeded in the scene.",
+                fixmessage: "Controllers are correctly set up in current scene",
                 checkAction: () =>
                 {
                     string newMessage;

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -189,31 +189,49 @@ namespace Cognitive3D
                 level: ProjectValidation.ItemLevel.Required, 
                 category: CATEGORY,
                 actionType: ProjectValidation.ItemAction.None,
-                message : "Controllers are not correctly set up.",
-                fixmessage: "Controllers are correctly set up in current scene",
+                message : "The maximum limit of controllers in the scene has been exceeded. Please remove any extra controller dynamic objects.",
+                fixmessage: "The maximum limit of controllers in the scene has not been exceeded.",
                 checkAction: () =>
                 {
                     string newMessage;
-                    string oldMessage = "Controllers are not correctly set up.";
+                    string oldMessage = "The maximum limit of controllers in the scene has been exceeded. Please remove any extra controller dynamic objects.";
                     if (TryGetControllers(out var _controllerNamesList))
                     {
                         if (_controllerNamesList.Count > 2)
                         {
-                            newMessage = oldMessage + $" The maximum limit of controllers in the scene has been exceeded. Please remove any extra controller dynamic objects. The detected controller objects are: {string.Join(", ", _controllerNamesList)}";
+                            newMessage = oldMessage + $" The detected controller objects are: {string.Join(", ", _controllerNamesList)}";
                             UpdateProjectValidationItemMessage(oldMessage, newMessage);
                         }
-                        else if (_controllerNamesList.Count < 2)
-                        {
-                            newMessage = oldMessage + " Less than 2 controllers are detected in the scene. You can configure the controllers in Cognitive3D > Scene Setup";
-                            UpdateProjectValidationItemMessage(oldMessage, newMessage);
-                        }
+
+                        return _controllerNamesList.Count <= 2;
                     }
                     
-                    return _controllerNamesList.Count == 2;
+                    return true;
                 },
                 fixAction: () =>
                 {
                     
+                }
+            );
+
+            ProjectValidation.AddItem(
+                level: ProjectValidation.ItemLevel.Required, 
+                category: CATEGORY,
+                actionType: ProjectValidation.ItemAction.Edit,
+                message : "Controllers are not correctly set up. Less than 2 controllers are detected in the scene. You can configure the controllers in Cognitive3D > Scene Setup",
+                fixmessage: "Controllers are correctly set up in current scene",
+                checkAction: () =>
+                {
+                    if (TryGetControllers(out var _controllerNamesList))
+                    {
+                        return _controllerNamesList.Count >= 2;
+                    }
+                    
+                    return false;
+                },
+                fixAction: () =>
+                {
+                    SceneSetupWindow.Init(SceneSetupWindow.Page.PlayerSetup);
                 }
             );
 #if C3D_OCULUS

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -31,12 +31,13 @@ namespace Cognitive3D
         /// </summary>
         internal enum ItemAction
         {
+            None = 0,
             // Related fix action is performed automatically once the "Fix" button is pressed, with no developer or user involvement required.
-            Fix = 0,
+            Fix = 1,
             // Requires updates and adjustments in the project or scene by developers or users once the "Edit" button is pressed
-            Edit = 1,
+            Edit = 2,
             // Necessary action is performed automatically once the "Apply" button is pressed, with no developer or user involvement required (used for recommonded items).
-            Apply = 2
+            Apply = 3
         }
 
         internal static readonly ProjectValidationItemRegistry registry = new ProjectValidationItemRegistry();

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -163,10 +163,13 @@ namespace Cognitive3D
                 {
                     if (!item.isIgnored)
                     {
-                        if (GUILayout.Button(buttonText, EditorCore.styles.MediumButton))
+                        if (buttonText != "None")
                         {
-                            ProjectValidation.FixItem(item);
-                            GenerateCompletedItemList();
+                            if (GUILayout.Button(buttonText, EditorCore.styles.MediumButton))
+                            {
+                                ProjectValidation.FixItem(item);
+                                GenerateCompletedItemList();
+                            }
                         }
 
                         if (GUILayout.Button("Ignore", EditorCore.styles.MediumButton))

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -124,19 +124,18 @@ namespace Cognitive3D
                             foreach (var item in list.items)
                             {
                                 string buttonText = item.actionType.ToString();
-                                if ((list.listName != "Completed" || list.listName != "Ignored") && (!item.isFixed && !item.isIgnored))
-                                {
-                                    DrawItem(item, list.listItemIcon, item.message, true, buttonText);
-                                }
 
                                 if (list.listName == "Ignored" && item.isIgnored)
                                 {
                                     DrawItem(item, null, item.message, true, buttonText);
-                                }
-                                
-                                if (list.listName == "Completed" && item.isFixed)
+                                } 
+                                else if (list.listName == "Completed" && item.isFixed)
                                 {
                                     DrawItem(item, list.listItemIcon, item.fixmessage, false, "");
+                                }
+                                else if (list.listName != "Completed" && !item.isFixed && !item.isIgnored)
+                                {
+                                    DrawItem(item, list.listItemIcon, item.message, true, buttonText);
                                 }
                             }
 


### PR DESCRIPTION
# Description

The following changes are made for a project validation item to ensure that each scene contains no more than 2 controller dynamic objects:

- Added a (required) validation item to check the number of controller dynamic objects in a scene.
- This validation item has no automatic fix action. Users must manually remove any additional dynamic object components.
- Updated `ItemAction` to include `None` enum for items without a fixAction.
- Implemented the `UpdateProjectValidationItemMessage` function for updating item's message. It checks for items containing the `oldmessage` and replaces it with `newmessage`.

Height Task ID(s) (If applicable): https://c3d.height.app/T-7856

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
