### PR TITLE
Add `isController` variable to dynamic aggregation manifest

### DIFF
--- a/Editor/DynamicObjectIdPoolInspector.cs
+++ b/Editor/DynamicObjectIdPoolInspector.cs
@@ -62,7 +62,7 @@ namespace Cognitive3D
                         foreach (var id in pool.Ids)
                         {
                             //TODO pools need a reference to a gameobject to aggregate data correctly
-                            /// NOTE: These objects will be treated as NOT CONTROLLERS
+                            /// NOTE: These will be treated as NOT CONTROLLERS
                             manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(pool.PrefabName, pool.MeshName, id, false,
                                 new float[3] { 1, 1, 1 },
                                 new float[3] { 0, 0, 0 },

--- a/Editor/DynamicObjectIdPoolInspector.cs
+++ b/Editor/DynamicObjectIdPoolInspector.cs
@@ -62,7 +62,8 @@ namespace Cognitive3D
                         foreach (var id in pool.Ids)
                         {
                             //TODO pools need a reference to a gameobject to aggregate data correctly
-                            manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(pool.PrefabName, pool.MeshName, id,
+                            /// NOTE: These objects will be treated as NOT CONTROLLERS
+                            manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(pool.PrefabName, pool.MeshName, id, false,
                                 new float[3] { 1, 1, 1 },
                                 new float[3] { 0, 0, 0 },
                                 new float[4] { 0,0,0,1 }));

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -326,7 +326,7 @@ namespace Cognitive3D
                 EditorCore.RefreshSceneVersion(delegate ()
                 {
                     AggregationManifest manifest = new AggregationManifest();
-                    manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.CustomId,
+                    manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.CustomId, dyn.IsController,
                         new float[3] { dyn.transform.lossyScale.x, dyn.transform.lossyScale.y, dyn.transform.lossyScale.z },
                         new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
                         new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));
@@ -341,7 +341,7 @@ namespace Cognitive3D
                     AggregationManifest manifest = new AggregationManifest();
                     for (int i = 0; i < dyn.IdPool.Ids.Length; i++)
                     {
-                        manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.IdPool.Ids[i],
+                        manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.IdPool.Ids[i], dyn.IsController,
                             new float[3] { dyn.transform.lossyScale.x, dyn.transform.lossyScale.y, dyn.transform.lossyScale.z },
                             new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
                             new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));

--- a/Editor/DynamicObjectsWindow.cs
+++ b/Editor/DynamicObjectsWindow.cs
@@ -29,28 +29,31 @@ namespace Cognitive3D
             public string name;
             public string mesh;
             public string id;
+            public bool isController;
             public float[] scaleCustom = new float[] { 1, 1, 1 };
             public float[] position = new float[] { 0, 0, 0 };
             public float[] rotation = new float[] { 0, 0, 0, 1 };
-            public AggregationManifestEntry(string _name, string _mesh, string _id, float[] _scaleCustom)
+            public AggregationManifestEntry(string _name, string _mesh, string _id, bool _isController, float[] _scaleCustom)
             {
                 name = _name;
                 mesh = _mesh;
                 id = _id;
+                isController = _isController;
                 scaleCustom = _scaleCustom;
             }
-            public AggregationManifestEntry(string _name, string _mesh, string _id, float[] _scaleCustom, float[] _position, float[] _rotation)
+            public AggregationManifestEntry(string _name, string _mesh, string _id, bool _isController, float[] _scaleCustom, float[] _position, float[] _rotation)
             {
                 name = _name;
                 mesh = _mesh;
                 id = _id;
+                isController = _isController;
                 scaleCustom = _scaleCustom;
                 position = _position;
                 rotation = _rotation;
             }
             public override string ToString()
             {
-                return "{\"name\":\"" + name + "\",\"mesh\":\"" + mesh + "\",\"id\":\"" + id +
+                return "{\"name\":\"" + name + "\",\"mesh\":\"" + mesh + "\",\"id\":\"" + id + "\",\"isController\":\"" + isController +
                     "\",\"scaleCustom\":[" + scaleCustom[0].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + scaleCustom[1].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + scaleCustom[2].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) +
                     "],\"initialPosition\":[" + position[0].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + position[1].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + position[2].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) +
                     "],\"initialRotation\":[" + rotation[0].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + rotation[1].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + rotation[2].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "," + rotation[3].ToString("0.0000", System.Globalization.CultureInfo.InvariantCulture) + "]}";
@@ -76,6 +79,7 @@ namespace Cognitive3D
                     if (!string.IsNullOrEmpty(dynamic.MeshName))
                     {
                         objects.Add(new AggregationManifest.AggregationManifestEntry(dynamic.gameObject.name, dynamic.MeshName, dynamic.CustomId.ToString(),
+                            dynamic.IsController,
                             new float[] { dynamic.transform.lossyScale.x, dynamic.transform.lossyScale.y, dynamic.transform.lossyScale.z },
                             new float[] { dynamic.transform.position.x, dynamic.transform.position.y, dynamic.transform.position.z },
                             new float[] { dynamic.transform.rotation.x, dynamic.transform.rotation.y, dynamic.transform.rotation.z, dynamic.transform.rotation.w }));
@@ -1312,7 +1316,7 @@ namespace Cognitive3D
                             {
                                 foreach (var poolid in entry.poolReference.Ids)
                                 {
-                                    manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(entry.poolReference.PrefabName, entry.poolReference.MeshName, poolid, new float[] { 1, 1, 1 }, new float[] { 0, 0, 0 }, new float[] { 0, 0, 0, 1 }));
+                                    manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(entry.poolReference.PrefabName, entry.poolReference.MeshName, poolid, entry.objectReference.IsController, new float[] { 1, 1, 1 }, new float[] { 0, 0, 0 }, new float[] { 0, 0, 0, 1 }));
                                 }
                             }
                         }
@@ -1354,7 +1358,7 @@ namespace Cognitive3D
                     //don't include meshes with empty mesh names in manifest
                     if (!string.IsNullOrEmpty(dynamic.MeshName))
                     {
-                        manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dynamic.gameObject.name, dynamic.MeshName, dynamic.CustomId.ToString(),
+                        manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dynamic.gameObject.name, dynamic.MeshName, dynamic.CustomId.ToString(), dynamic.IsController,
                             new float[] { dynamic.transform.lossyScale.x, dynamic.transform.lossyScale.y, dynamic.transform.lossyScale.z },
                             new float[] { dynamic.transform.position.x, dynamic.transform.position.y, dynamic.transform.position.z },
                             new float[] { dynamic.transform.rotation.x, dynamic.transform.rotation.y, dynamic.transform.rotation.z, dynamic.transform.rotation.w }));

--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -2046,6 +2046,10 @@ namespace Cognitive3D
                 sb.Append(entry.id);
                 sb.Append("\",");
 
+                sb.Append("\"isController\":\"");
+                sb.Append(entry.isController);
+                sb.Append("\",");
+
                 sb.Append("\"mesh\":\"");
                 sb.Append(entry.mesh);
                 sb.Append("\",");


### PR DESCRIPTION
# Description

We need a way to filter out controllers from Scene Viewer. To that end, we are adding the `isController` field to the dynamic manifest.

Height Task ID(s) (If applicable): T-8490

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
