### PR TITLE
Scene Version Validation Items

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -335,7 +335,7 @@ namespace Cognitive3D
             }
         }
 
-        private static void GetSceneVersionResponse(int responsecode, string error, string text)
+        internal static void GetSceneVersionResponse(int responsecode, string error, string text)
         {
             if (responsecode != 200)
             {

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -41,7 +41,7 @@ namespace Cognitive3D
 
             AddProjectValidationItems();
             ProjectValidation.SetIgnoredItemsFromLog();
-            ProjectValidationGUI.Reset();
+            ProjectValidation.ResetGUI();
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -814,15 +814,6 @@ namespace Cognitive3D
 
 #endif
         }
-
-        /// <summary>
-        /// Regenerates the validation item list by clearing the existing items and rebuilding the list
-        /// </summary>
-        public static void RegenerateProjectValidationItems()
-        {
-            ProjectValidation.Reset();
-            DelayAndInitializeProjectValidation();
-        }
         
         /// <summary>
         /// Reevaluates all validation items and updates their fixed status

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -87,8 +87,8 @@ namespace Cognitive3D
                                 level: ProjectValidation.ItemLevel.Required, 
                                 category: CATEGORY,
                                 actionType: ProjectValidation.ItemAction.Fix,
-                                message: "Current scene not found on dashboard.",
-                                fixmessage: "Current scene found on dashboard.",
+                                message: "Current scene version not found on dashboard. Set to the latest version?",
+                                fixmessage: "Current scene version found on dashboard.",
                                 checkAction: () =>
                                 {
                                     return true;
@@ -105,8 +105,8 @@ namespace Cognitive3D
                                 level: ProjectValidation.ItemLevel.Required, 
                                 category: CATEGORY,
                                 actionType: ProjectValidation.ItemAction.Fix,
-                                message: "This scene not found on dashboard.",
-                                fixmessage: "Use latest dashboard's scene version.",
+                                message: "Current scene version not found on dashboard. Set to the latest version?",
+                                fixmessage: "Current scene version found on dashboard.",
                                 checkAction: () =>
                                 {
                                     return false;

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -125,7 +125,7 @@ namespace Cognitive3D
                                 level: ProjectValidation.ItemLevel.Recommended, 
                                 category: CATEGORY,
                                 actionType: ProjectValidation.ItemAction.Apply,
-                                message: "No latest scene version is used.",
+                                message: "No latest scene version is used. Set to the latest version?",
                                 fixmessage: "Latest scene version is used.",
                                 checkAction: () =>
                                 {
@@ -143,7 +143,7 @@ namespace Cognitive3D
                                 level: ProjectValidation.ItemLevel.Recommended, 
                                 category: CATEGORY,
                                 actionType: ProjectValidation.ItemAction.Apply,
-                                message: "No latest scene version is used.",
+                                message: "No latest scene version is used. Set to the latest version?",
                                 fixmessage: "Latest scene version is used.",
                                 checkAction: () =>
                                 {

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -297,7 +297,7 @@ namespace Cognitive3D
                         if (_controllerNamesList.Count > 2)
                         {
                             newMessage = oldMessage + $" The detected controller objects are: {string.Join(", ", _controllerNamesList)}";
-                            UpdateProjectValidationItemMessage(oldMessage, newMessage);
+                            ProjectValidation.UpdateItemMessage(oldMessage, newMessage);
                         }
 
                         return _controllerNamesList.Count <= 2;
@@ -813,23 +813,6 @@ namespace Cognitive3D
     #endif
 
 #endif
-        }
-
-        /// <summary>
-        /// Updates the message of a validation item that contain the specified message
-        /// </summary>
-        /// <param name="oldmessage">The message to search for in the validation items</param>
-        /// <param name="newmessage">The new message to replace the old message with</param>
-        public static void UpdateProjectValidationItemMessage(string oldmessage, string newmessage)
-        {
-            var items = ProjectValidation.registry.GetAllItems();
-            foreach (var item in items)
-            {
-                if (item.message.Contains(oldmessage))
-                {
-                    item.message = newmessage;
-                }
-            }
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -292,7 +292,7 @@ namespace Cognitive3D
                 {
                     string newMessage;
                     string oldMessage = "The maximum limit of controllers in the scene has been exceeded. Please remove any extra controller dynamic objects.";
-                    if (TryGetControllers(out var _controllerNamesList))
+                    if (ProjectValidation.TryGetControllers(out var _controllerNamesList))
                     {
                         if (_controllerNamesList.Count > 2)
                         {
@@ -319,7 +319,7 @@ namespace Cognitive3D
                 fixmessage: "Controllers are correctly set up in current scene",
                 checkAction: () =>
                 {
-                    if (TryGetControllers(out var _controllerNamesList))
+                    if (ProjectValidation.TryGetControllers(out var _controllerNamesList))
                     {
                         return _controllerNamesList.Count >= 2;
                     }
@@ -813,31 +813,6 @@ namespace Cognitive3D
     #endif
 
 #endif
-        }
-
-        /// <summary>
-        /// Attempts to retrieve a list of controller names from the active scene.
-        /// If no controllers are found, the function returns false
-        /// </summary>
-        /// <param name="controllerNamesList">An output list of controller names if found</param>
-        /// <returns>Returns true if controllers are found, otherwise false</returns>
-        internal static bool TryGetControllers(out List<String> controllerNamesList)
-        {
-            controllerNamesList = new List<string>();
-            ProjectValidation.FindComponentInActiveScene<DynamicObject>(out var controllers);
-            if (controllers == null)
-            {
-                return false;
-            }
-
-            foreach (var controller in controllers)
-            {
-                if (controller.IsController)
-                {
-                    controllerNamesList.Add(controller.name);
-                }
-            }
-            return true;
         }
     }
 }

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -814,19 +814,6 @@ namespace Cognitive3D
 
 #endif
         }
-        
-        /// <summary>
-        /// Reevaluates all validation items and updates their fixed status
-        /// </summary>
-        /// Save this function for later
-        public static void UpdateProjectValidationItemStatus()
-        {
-            var items = ProjectValidation.registry.GetAllItems();
-            foreach (var item in items)
-            {
-                item.isFixed = item.checkAction();
-            }
-        }
 
         /// <summary>
         /// Updates the message of a validation item that contain the specified message

--- a/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
@@ -36,8 +36,7 @@ namespace Cognitive3D
         // Update project validation items when a new scene opens
         private static void OnSceneOpened(Scene scene, OpenSceneMode mode)
         {
-            ProjectValidation.Reset();
-            ProjectValidationItems.WaitBeforeProjectValidation();
+            ProjectValidationItems.RegenerateProjectValidationItems();
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItemsStatus.cs
@@ -36,7 +36,7 @@ namespace Cognitive3D
         // Update project validation items when a new scene opens
         private static void OnSceneOpened(Scene scene, OpenSceneMode mode)
         {
-            ProjectValidationItems.RegenerateProjectValidationItems();
+            ProjectValidation.RegenerateItems();
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -142,7 +142,7 @@ namespace Cognitive3D
             Scene currentScene = SceneManager.GetActiveScene();
             EditorSceneManager.SaveScene(currentScene);
 
-            ProjectValidationItems.UpdateProjectValidationItemStatus();
+            ProjectValidationItems.RegenerateProjectValidationItems();
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Cognitive3D
                 ProjectValidationLog.RemoveIgnoreItem(item.message);
             }
             
-            ProjectValidationItems.UpdateProjectValidationItemStatus();
+            ProjectValidationItems.RegenerateProjectValidationItems();
         }
 
         /// <summary>
@@ -170,6 +170,14 @@ namespace Cognitive3D
         internal static void SetIgnoredItemsFromLog()
         {
             registry.SetIgnoredItemsFromLog(ProjectValidationLog.GetLogIgnoreItems());
+        }
+
+        /// <summary>
+        /// Removes a <see cref="ProjectValidationItem"/> item from registry
+        /// </summary>
+        internal static void RemoveItem(Hash128 id)
+        {
+            registry.RemoveItem(id);
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -241,6 +241,31 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Attempts to retrieve a list of controller names from the active scene.
+        /// If no controllers are found, the function returns false
+        /// </summary>
+        /// <param name="controllerNamesList">An output list of controller names if found</param>
+        /// <returns>Returns true if controllers are found, otherwise false</returns>
+        internal static bool TryGetControllers(out List<String> controllerNamesList)
+        {
+            controllerNamesList = new List<string>();
+            ProjectValidation.FindComponentInActiveScene<DynamicObject>(out var controllers);
+            if (controllers == null)
+            {
+                return false;
+            }
+
+            foreach (var controller in controllers)
+            {
+                if (controller.IsController)
+                {
+                    controllerNamesList.Add(controller.name);
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
         /// Searches through game objects in active scene to find a component
         /// </summary>
         /// <typeparam name="T">Type of target component</typeparam>

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -142,7 +142,7 @@ namespace Cognitive3D
             Scene currentScene = SceneManager.GetActiveScene();
             EditorSceneManager.SaveScene(currentScene);
 
-            ProjectValidationItems.RegenerateProjectValidationItems();
+            ProjectValidation.RegenerateItems();
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Cognitive3D
                 ProjectValidationLog.RemoveIgnoreItem(item.message);
             }
             
-            ProjectValidationItems.RegenerateProjectValidationItems();
+            ProjectValidation.RegenerateItems();
         }
 
         /// <summary>
@@ -178,6 +178,15 @@ namespace Cognitive3D
         internal static void RemoveItem(Hash128 id)
         {
             registry.RemoveItem(id);
+        }
+
+        /// <summary>
+        /// Regenerates the validation item list by clearing the existing items and rebuilding the list
+        /// </summary>
+        public static void RegenerateItems()
+        {
+            Reset();
+            ProjectValidationItems.DelayAndInitializeProjectValidation();
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -220,6 +220,14 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Resets project validation window GUI
+        /// </summary>
+        internal static void ResetGUI()
+        {
+            ProjectValidationGUI.Reset();
+        }
+
+        /// <summary>
         /// Resets ignored <see cref="ProjectValidationItem"/> items
         /// </summary>
         internal static void ResetIgnoredItems()

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -181,6 +181,19 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Reevaluates all validation items and updates their fixed status
+        /// </summary>
+        /// Save this function for later
+        public static void UpdateItemFixedStatus()
+        {
+            var items = ProjectValidation.registry.GetAllItems();
+            foreach (var item in items)
+            {
+                item.isFixed = item.checkAction();
+            }
+        }
+
+        /// <summary>
         /// Regenerates the validation item list by clearing the existing items and rebuilding the list
         /// </summary>
         public static void RegenerateItems()

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -181,12 +181,29 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Updates the message of a validation item that contain the specified message
+        /// </summary>
+        /// <param name="oldmessage">The message to search for in the validation items</param>
+        /// <param name="newmessage">The new message to replace the old message with</param>
+        public static void UpdateItemMessage(string oldmessage, string newmessage)
+        {
+            var items = registry.GetAllItems();
+            foreach (var item in items)
+            {
+                if (item.message.Contains(oldmessage))
+                {
+                    item.message = newmessage;
+                }
+            }
+        }
+
+        /// <summary>
         /// Reevaluates all validation items and updates their fixed status
         /// </summary>
         /// Save this function for later
         public static void UpdateItemFixedStatus()
         {
-            var items = ProjectValidation.registry.GetAllItems();
+            var items = registry.GetAllItems();
             foreach (var item in items)
             {
                 item.isFixed = item.checkAction();

--- a/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
+++ b/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
@@ -17,7 +17,7 @@ namespace Cognitive3D
         // Prompts a project validation popup if the project is not verified and the app version has changed
         public void OnPreprocessBuild(BuildReport report)
         {
-            ProjectValidationItems.UpdateProjectValidationItemStatus();
+            ProjectValidationItems.RegenerateProjectValidationItems();
             CheckCachedAppVersion();
             string currentAppVer = Application.version;
 
@@ -58,7 +58,7 @@ namespace Cognitive3D
         // Updates and refreshes project verification items after build
         public void OnPostprocessBuild(BuildReport report)
         {
-            ProjectValidationItems.WaitBeforeProjectValidation();
+            ProjectValidationItems.DelayAndInitializeProjectValidation();
             ProjectValidationGUI.Reset();
         }
     }

--- a/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
+++ b/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
@@ -17,7 +17,7 @@ namespace Cognitive3D
         // Prompts a project validation popup if the project is not verified and the app version has changed
         public void OnPreprocessBuild(BuildReport report)
         {
-            ProjectValidationItems.RegenerateProjectValidationItems();
+            ProjectValidation.RegenerateItems();
             CheckCachedAppVersion();
             string currentAppVer = Application.version;
 

--- a/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
+++ b/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
@@ -59,7 +59,7 @@ namespace Cognitive3D
         public void OnPostprocessBuild(BuildReport report)
         {
             ProjectValidationItems.DelayAndInitializeProjectValidation();
-            ProjectValidationGUI.Reset();
+            ProjectValidation.ResetGUI();
         }
     }
 }

--- a/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
+++ b/Editor/ProjectValidation/ProjectValidationBuildProcess.cs
@@ -58,8 +58,7 @@ namespace Cognitive3D
         // Updates and refreshes project verification items after build
         public void OnPostprocessBuild(BuildReport report)
         {
-            ProjectValidationItems.DelayAndInitializeProjectValidation();
-            ProjectValidation.ResetGUI();
+            ProjectValidation.RegenerateItems();
         }
     }
 }

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -29,7 +29,7 @@ namespace Cognitive3D
             if (state == PlayModeStateChange.EnteredEditMode)
             {
                 ProjectValidation.SetIgnoredItemsFromLog();
-                ProjectValidationItems.RegenerateProjectValidationItems();
+                ProjectValidation.RegenerateItems();
                 Reset();
             }
         }
@@ -73,7 +73,7 @@ namespace Cognitive3D
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button(new GUIContent(EditorCore.RefreshIcon, "Refresh Checklists"), EditorCore.styles.IconButton))
                 {
-                    ProjectValidationItems.RegenerateProjectValidationItems();
+                    ProjectValidation.RegenerateItems();
                     Reset();
                 }
                 if (GUILayout.Button(new GUIContent(EditorCore.SettingsIcon2, "Additional Actions"), EditorCore.styles.IconButton))
@@ -89,7 +89,7 @@ namespace Cognitive3D
                     {
                         ProjectValidationLog.ClearIgnoreItems();
                         ProjectValidation.ResetIgnoredItems();
-                        ProjectValidationItems.RegenerateProjectValidationItems();
+                        ProjectValidation.RegenerateItems();
                         Reset();
                     });
 

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -29,7 +29,7 @@ namespace Cognitive3D
             if (state == PlayModeStateChange.EnteredEditMode)
             {
                 ProjectValidation.SetIgnoredItemsFromLog();
-                ProjectValidationItems.UpdateProjectValidationItemStatus();
+                ProjectValidationItems.RegenerateProjectValidationItems();
                 Reset();
             }
         }
@@ -73,7 +73,7 @@ namespace Cognitive3D
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button(new GUIContent(EditorCore.RefreshIcon, "Refresh Checklists"), EditorCore.styles.IconButton))
                 {
-                    ProjectValidationItems.UpdateProjectValidationItemStatus();
+                    ProjectValidationItems.RegenerateProjectValidationItems();
                     Reset();
                 }
                 if (GUILayout.Button(new GUIContent(EditorCore.SettingsIcon2, "Additional Actions"), EditorCore.styles.IconButton))
@@ -89,7 +89,7 @@ namespace Cognitive3D
                     {
                         ProjectValidationLog.ClearIgnoreItems();
                         ProjectValidation.ResetIgnoredItems();
-                        ProjectValidationItems.UpdateProjectValidationItemStatus();
+                        ProjectValidationItems.RegenerateProjectValidationItems();
                         Reset();
                     });
 

--- a/Editor/ProjectValidation/ProjectValidationSettingsProvider.cs
+++ b/Editor/ProjectValidation/ProjectValidationSettingsProvider.cs
@@ -34,7 +34,7 @@ namespace Cognitive3D
 
         public override void OnActivate(string searchContext, VisualElement rootElement)
         {
-            ProjectValidationItems.UpdateProjectValidationItemStatus();
+            ProjectValidationItems.RegenerateProjectValidationItems();
         }
 
         public override void OnGUI(string searchContext)

--- a/Editor/ProjectValidation/ProjectValidationSettingsProvider.cs
+++ b/Editor/ProjectValidation/ProjectValidationSettingsProvider.cs
@@ -34,7 +34,7 @@ namespace Cognitive3D
 
         public override void OnActivate(string searchContext, VisualElement rootElement)
         {
-            ProjectValidationItems.RegenerateProjectValidationItems();
+            ProjectValidation.RegenerateItems();
         }
 
         public override void OnGUI(string searchContext)


### PR DESCRIPTION
# Description

The following updates introduce two new validation items for checking scene versions:

- Added a validation check in `ProjectValidationItems.cs` to ensure the latest version of a scene is used
- Implemented a check in `ProjectValidationItems.cs` to verify if a scene exists on the dashboard
- Added `RegenerateItems()` in `ProjectValidation.cs` to clear and rebuild the list of items
- Refactored logic and moved relevant code to `ProjectValidation.cs`, designating it as the core of project validation

Height Task ID(s) (If applicable): https://c3d.height.app/T-8771

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
