### PR TITLE
Unity Netcode Multiplayer Support

### DIFF
--- a/Editor/Cognitive3DEditor.asmdef
+++ b/Editor/Cognitive3DEditor.asmdef
@@ -23,7 +23,8 @@
         "Unity.XR.OpenXR.Features.MetaQuestSupport",
         "Unity.XR.PICO",
         "Unity.XR.PicoXR",
-        "meta.xr.mrutilitykit"
+        "meta.xr.mrutilitykit",
+        "Unity.Netcode.Runtime"
     ],
     "includePlatforms": [
         "Editor"
@@ -74,6 +75,11 @@
             "name": "com.meta.xr.mrutilitykit",
             "expression": "65.0.0",
             "define": "COGNITIVE3D_INCLUDE_META_XR_UTILITY"
+        },
+        {
+            "name": "com.unity.netcode.gameobjects",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_UNITY_NETCODE"
         }
     ],
     "noEngineReferences": false

--- a/Editor/ProjectSetupWindow.cs
+++ b/Editor/ProjectSetupWindow.cs
@@ -63,7 +63,7 @@ namespace Cognitive3D
             Recompile,
             Wave,
             NextSteps,
-            PhotonMultiplayerSetup,
+            MultiplayerSetup,
             DynamicSetup,
         }
         private Page _currentPage;
@@ -115,8 +115,8 @@ namespace Cognitive3D
                 case Page.DynamicSetup:
                     DynamicUpdate();
                     break;
-                case Page.PhotonMultiplayerSetup:
-                    PhotonMultiplayerSetup();
+                case Page.MultiplayerSetup:
+                    MultiplayerSetup();
                     break;
                 default:
                     throw new System.NotSupportedException();
@@ -872,7 +872,13 @@ namespace Cognitive3D
 #else
         bool wantPhotonPunSupport = false;
 #endif
-        void PhotonMultiplayerSetup()
+
+#if C3D_NETCODE
+        bool wantNetcodeSupport = true;
+#else
+        bool wantNetcodeSupport = false;
+#endif
+        void MultiplayerSetup()
         {
             GUI.Label(steptitlerect, "MUTLIPLAYER SUPPORT", "steptitle");
             GUI.Label(new Rect(30, 30, 440, 440), "You can enable multiplayer support here. Select the package or framework you are using below.", "normallabel");
@@ -897,6 +903,27 @@ namespace Cognitive3D
                 if (GUI.Button(checkboxRect1, EditorCore.BoxEmpty, "image_centered"))
                 {
                     wantPhotonPunSupport = true;
+                }
+            }
+
+            // Netcode
+            GUI.Label(new Rect(140, 130, 440, 440), "Unity Netcode for Gameobjects", "normallabel");
+            Rect infoRect2 = new Rect(400, 125, 30, 30);
+            GUI.Label(infoRect2, new GUIContent(EditorCore.Info, "Enables support for Unity Netcode for Gameobjects. Requires Unity Netcode Runtime assemblies."), "image_centered");
+
+            Rect checkboxRect2 = new Rect(105, 125, 30, 30);
+            if (wantNetcodeSupport)
+            {
+                if (GUI.Button(checkboxRect2, EditorCore.BoxCheckmark, "image_centered"))
+                {
+                    wantNetcodeSupport = false;
+                }
+            }
+            else
+            {
+                if (GUI.Button(checkboxRect2, EditorCore.BoxEmpty, "image_centered"))
+                {
+                    wantNetcodeSupport = true;
                 }
             }
         }
@@ -997,7 +1024,7 @@ namespace Cognitive3D
                     }
                     break;
                 case Page.SDKSelection:
-                    onclick = () => currentPage = Page.PhotonMultiplayerSetup;
+                    onclick = () => currentPage = Page.MultiplayerSetup;
                     break;
                 case Page.Recompile:
                     onclick = null;
@@ -1032,7 +1059,7 @@ namespace Cognitive3D
                     break;
                 case Page.Wave:
                     break;
-                case Page.PhotonMultiplayerSetup:
+                case Page.MultiplayerSetup:
                     if (wantPhotonPunSupport)
                     { 
                         if (!selectedsdks.Contains("C3D_PHOTON"))
@@ -1043,6 +1070,18 @@ namespace Cognitive3D
                     else
                     { 
                         selectedsdks.Remove("C3D_PHOTON");
+                    }
+
+                    if (wantNetcodeSupport)
+                    { 
+                        if (!selectedsdks.Contains("C3D_NETCODE"))
+                        {
+                            selectedsdks.Add("C3D_NETCODE");
+                        }
+                    }
+                    else
+                    { 
+                        selectedsdks.Remove("C3D_NETCODE");
                     }
                     onclick += () => currentPage = Page.Glia;
                     break;
@@ -1088,7 +1127,7 @@ namespace Cognitive3D
                 case Page.SRAnipal:
                 case Page.Wave:
                 case Page.NextSteps:
-                    if (wantPhotonPunSupport) { onclick = () => currentPage = Page.PhotonMultiplayerSetup; }
+                    if (wantPhotonPunSupport || wantNetcodeSupport) { onclick = () => currentPage = Page.MultiplayerSetup; }
                     else { onclick = () => currentPage = Page.SDKSelection; }
                     break;
                 case Page.DynamicSetup:
@@ -1100,7 +1139,7 @@ namespace Cognitive3D
                 case Page.Recompile:
                     buttonDisabled = true;
                     break;
-                case Page.PhotonMultiplayerSetup:
+                case Page.MultiplayerSetup:
                     onclick += () => currentPage = Page.SDKSelection;
                     break;
                 default:

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -813,6 +813,34 @@ namespace Cognitive3D
     #endif
 
 #endif
+
+#if C3D_NETCODE
+            ProjectValidation.AddItem(
+                level: ProjectValidation.ItemLevel.Recommended, 
+                category: CATEGORY,
+                actionType: ProjectValidation.ItemAction.Apply,
+                message: "No Network Manager found in current scene. To enable Unity Netcode support, the Network Manager needs to be present in one of the project scenes. Add a Network Manager to current scene? If there's already a Network Manager in one of the project scenes, click \"Ignore\".",
+                fixmessage: "Network Manager found in current scene.",
+                checkAction: () =>
+                {
+                    if (ProjectValidation.FindComponentInActiveScene<Unity.Netcode.NetworkManager>())
+                    {
+                        return true;
+                    }
+
+                    return false;
+                },
+                fixAction: () =>
+                {
+                    GameObject networkManagerObject = new GameObject("NetworkManager");
+
+                    Unity.Netcode.NetworkManager networkManager = networkManagerObject.AddComponent<Unity.Netcode.NetworkManager>();
+                    Unity.Netcode.Transports.UTP.UnityTransport transport = networkManagerObject.AddComponent<Unity.Netcode.Transports.UTP.UnityTransport>();
+
+                    networkManager.NetworkConfig.NetworkTransport = transport;
+                }
+            );
+#endif
         }
     }
 }

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -19,6 +19,10 @@ using UnityEditor.XR.LegacyInputHelpers;
 using Photon.Pun;
 #endif
 
+#if COGNITIVE3D_INCLUDE_UNITY_NETCODE
+using Unity.Netcode;
+#endif
+
 #if C3D_STEAMVR2
 using Valve.VR;
 using System.IO;
@@ -296,6 +300,28 @@ namespace Cognitive3D
                 {
                     DestroyImmediate(Cognitive3D_Manager.Instance.gameObject.GetComponent<PhotonView>());
                 }
+    #endif
+#endif
+
+#if COGNITIVE3D_INCLUDE_UNITY_NETCODE
+    #if C3D_NETCODE
+            if (Cognitive3D_Manager.Instance.gameObject.GetComponent<NetcodeMultiplayer>() == null)
+            {
+                Cognitive3D_Manager.Instance.gameObject.AddComponent<NetcodeMultiplayer>();
+            }
+            if (Cognitive3D_Manager.Instance.gameObject.GetComponent<NetworkObject>() == null)
+            {
+                Cognitive3D_Manager.Instance.gameObject.AddComponent<NetworkObject>();
+            }
+    #else
+            if (Cognitive3D_Manager.Instance.gameObject.GetComponent<NetcodeMultiplayer>() != null)
+            {
+                DestroyImmediate(Cognitive3D_Manager.Instance.gameObject.GetComponent<NetcodeMultiplayer>());
+            }
+            if (Cognitive3D_Manager.Instance.gameObject.GetComponent<NetworkObject>() != null)
+            {
+                DestroyImmediate(Cognitive3D_Manager.Instance.gameObject.GetComponent<NetworkObject>());
+            }
     #endif
 #endif
         }

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -63,6 +63,11 @@
             "name": "com.unity.services.lobby",
             "expression": "",
             "define": "COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES"
+        },
+        {
+            "name": "com.unity.netcode.gameobjects",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_UNITY_NETCODE"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -23,8 +23,7 @@
         "PhotonUnityNetworking",
         "PhotonRealtime",
         "meta.xr.mrutilitykit",
-        "Unity.Netcode.Runtime",
-        "Unity.Services.Lobbies"
+        "Unity.Netcode.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -58,11 +57,6 @@
             "name": "com.meta.xr.mrutilitykit",
             "expression": "",
             "define": "COGNITIVE3D_INCLUDE_META_XR_UTILITY"
-        },
-        {
-            "name": "com.unity.services.lobby",
-            "expression": "",
-            "define": "COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES"
         },
         {
             "name": "com.unity.netcode.gameobjects",

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -22,7 +22,9 @@
         "Unity.XR.PicoXR",
         "PhotonUnityNetworking",
         "PhotonRealtime",
-        "meta.xr.mrutilitykit"
+        "meta.xr.mrutilitykit",
+        "Unity.Netcode.Runtime",
+        "Unity.Services.Lobbies"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -56,6 +58,11 @@
             "name": "com.meta.xr.mrutilitykit",
             "expression": "",
             "define": "COGNITIVE3D_INCLUDE_META_XR_UTILITY"
+        },
+        {
+            "name": "com.unity.services.lobby",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Components/NetcodeMultiplayer.cs
+++ b/Runtime/Components/NetcodeMultiplayer.cs
@@ -75,9 +75,6 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnUpdate(float deltaTime)
         {
-            // We don't want these lines to execute if component disabled
-            // Without this condition, these lines will execute regardless
-            //      of component being disabled since this function is bound to C3D_Manager.Update on SessionBegin()
             if (!Cognitive3D_Manager.IsInitialized) { return; }
             if (transport && Unity.Netcode.NetworkManager.Singleton.IsListening)
             {

--- a/Runtime/Components/NetcodeMultiplayer.cs
+++ b/Runtime/Components/NetcodeMultiplayer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+#if COGNITIVE3D_INCLUDE_UNITY_NETCODE
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 
@@ -94,13 +95,13 @@ namespace Cognitive3D.Components
 
         protected void OnClientDisconnectCallback(ulong clientId)
         {
-            if (Unity.Netcode.NetworkManager.Singleton.IsHost)
+            if (IsHost)
             {
                 new CustomEvent("c3d.multiplayer.host_disconnected")
                     .SetProperty("Player ID", clientId)
                     .Send();
             }
-            else if (Unity.Netcode.NetworkManager.Singleton.IsClient)
+            else if (IsClient)
             {
                 new CustomEvent("c3d.multiplayer.client_disconnected")
                     .SetProperty("Player ID", clientId)
@@ -235,3 +236,4 @@ namespace Cognitive3D.Components
 #endregion
     }
 }
+#endif

--- a/Runtime/Components/NetcodeMultiplayer.cs
+++ b/Runtime/Components/NetcodeMultiplayer.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Netcode;
+using Unity.Netcode.Transports.UTP;
+
+#if COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES
+using Unity.Services.Lobbies;
+using Unity.Services.Lobbies.Models;
+#endif
+
+namespace Cognitive3D.Components
+{
+    [DisallowMultipleComponent]
+    public class NetcodeMultiplayer : AnalyticsComponentBase
+    {
+        private UnityTransport transport;
+        private ulong localClientId;
+
+        private string serverAddress;
+        private int port;
+
+        private Lobby currentLobby;
+        private string lobbyID;
+
+        protected override void OnSessionBegin()
+        {
+            if (Unity.Netcode.NetworkManager.Singleton != null)
+            {
+                Cognitive3D_Manager.OnPreSessionEnd += OnPreSessionEnd;
+
+                Unity.Netcode.NetworkManager.Singleton.OnClientConnectedCallback += OnClientConnectedCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnClientDisconnectCallback += OnClientDisconnectCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnServerStarted += OnServerStartedCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnServerStopped += OnServerStoppedCallback;
+            }
+        }
+
+        private void OnPreSessionEnd()
+        {
+            if (Unity.Netcode.NetworkManager.Singleton != null)
+            {
+                Cognitive3D_Manager.OnPreSessionEnd -= OnPreSessionEnd;
+
+                Unity.Netcode.NetworkManager.Singleton.OnClientConnectedCallback -= OnClientConnectedCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnClientDisconnectCallback -= OnClientDisconnectCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnServerStarted -= OnServerStartedCallback;
+                Unity.Netcode.NetworkManager.Singleton.OnServerStopped -= OnServerStoppedCallback;
+            }
+        }
+
+        protected void OnClientConnectedCallback(ulong clientId)
+        {
+            SetMultiplayerSessionProperties();
+#if COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES
+            GetLobbiesInfo();
+#endif
+
+            if (Unity.Netcode.NetworkManager.Singleton.IsHost)
+            {
+                GenerateAndSetLobbyIDForAllClients();
+                
+                new CustomEvent("c3d.multiplayer.thisHostConnected")
+                    .SetProperty("Player ID", clientId)
+                    .SetProperty("Number of players in room", Unity.Netcode.NetworkManager.Singleton.ConnectedClientsList.Count)
+                    .Send();
+            } 
+            else if (Unity.Netcode.NetworkManager.Singleton.IsClient)
+            {
+                new CustomEvent("c3d.multiplayer.thisClientConnected")
+                    .SetProperty("Player ID", clientId)
+                    .SetProperty("Number of players in room", Unity.Netcode.NetworkManager.Singleton.ConnectedClientsList.Count)
+                    .Send();
+            }
+
+            SetLobbyAndViewID(lobbyID);
+            SendClientConnected(clientId);
+        }
+
+        protected void OnClientDisconnectCallback(ulong clientId)
+        {
+            if (Unity.Netcode.NetworkManager.Singleton.IsHost)
+            {
+                new CustomEvent("c3d.multiplayer.thisHostDisconnected")
+                    .SetProperty("Player ID", clientId)
+                    .Send();
+            }
+            else if (Unity.Netcode.NetworkManager.Singleton.IsClient)
+            {
+                new CustomEvent("c3d.multiplayer.thisClientDisconnected")
+                    .SetProperty("Player ID", clientId)
+                    .Send();
+            }
+        }
+
+        protected void OnServerStartedCallback()
+        {
+            new CustomEvent("c3d.multiplayer.serverStarted")
+                    .Send();
+        }
+
+        protected void OnServerStoppedCallback(bool isHostShutdown)
+        {
+            if (isHostShutdown)
+            {
+                new CustomEvent("c3d.multiplayer.serverStopped")
+                    .SetProperty("Reason", "Shutdown by host")
+                    .Send();
+            }
+            else
+            {
+                new CustomEvent("c3d.multiplayer.serverStopped")
+                    .SetProperty("Reason", "Shutdown due to external reasons")
+                    .Send();
+            }
+            
+        }
+
+#if COGNITIVE3D_INCLUDE_UNITY_LOBBY_SERVICES
+        public async void GetLobbiesInfo()
+        {
+            try
+            {
+                QueryResponse response = await Lobbies.Instance.QueryLobbiesAsync();
+                List<Lobby> lobbies = response.Results;
+                
+                foreach (Lobby lobby in lobbies)
+                {
+                    foreach (var player in lobby.Players)
+                    {
+                        if (player.Id == localClientId.ToString())
+                        {
+                            currentLobby = lobby;
+                        }
+                    }
+                }
+
+                if (currentLobby != null)
+                {
+                    Cognitive3D_Manager.SetSessionProperty("c3d.multiplayer.photonRoomName", currentLobby.Name);
+                    Cognitive3D_Manager.SetSessionProperty("c3d.multiplayer.maxNumberConnections", currentLobby.MaxPlayers);
+                }
+            }
+            catch (SystemException e)
+            {
+                Util.LogOnce($"Failed to retrieve list of lobbies: {e.Message}", LogType.Error);
+            }
+        } 
+#endif
+
+        /// <summary>
+        /// Sets session properties for multiplayer related details
+        /// </summary>
+        private void SetMultiplayerSessionProperties()
+        {
+            localClientId = Unity.Netcode.NetworkManager.Singleton.LocalClientId;
+            transport = Unity.Netcode.NetworkManager.Singleton.GetComponent<UnityTransport>();
+            if (transport)
+            {
+                port = transport.ConnectionData.Port;
+                serverAddress = transport.ConnectionData.Address;
+            }
+            
+            Cognitive3D_Manager.SetSessionProperty("c3d.multiplayer.localClientId", localClientId);
+            Cognitive3D_Manager.SetSessionProperty("c3d.multiplayer.serverAddress", serverAddress);
+            Cognitive3D_Manager.SetSessionProperty("c3d.multiplayer.port", port);
+        }
+
+        /// <summary>
+        /// Generate and assigns a lobby id for all participants
+        /// Helpful for identifying multiple individual sessions as part of a multiplayer sessions
+        /// For more info, see: https://docs.cognitive3d.com/unity/multiplayer/#lobby-id
+        /// </summary>
+        private void GenerateAndSetLobbyIDForAllClients()
+        {
+            lobbyID = System.Guid.NewGuid().ToString();
+        }
+
+#region RPC
+        /// <summary>
+        /// RPC to set lobbyID for all participants
+        /// </summary>
+        /// <param name="lobbyID">The lobbyID as a string</param>
+        [ClientRpc]
+        private void SetLobbyAndViewID(string lobbyID)
+        {
+            Cognitive3D_Manager.SetLobbyId(lobbyID);
+        }
+
+        /// <summary>
+        /// RPC when a client connects <br/>
+        /// For other users: Participant A sends event when participant B connects
+        /// </summary>
+        [ClientRpc]
+        private void SendClientConnected(ulong clientID)
+        {
+            // Send events only for "other" players
+            if (localClientId != clientID)
+            {
+                new CustomEvent("c3d.multiplayer.aNewClientConnected")
+                .SetProperty("Player ID", clientID)
+                .SetProperty("Number of players in room", Unity.Netcode.NetworkManager.Singleton.ConnectedClientsList.Count)
+                .Send();
+            }
+        }
+#endregion
+    }
+}

--- a/Runtime/Components/NetcodeMultiplayer.cs.meta
+++ b/Runtime/Components/NetcodeMultiplayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3024427577c48ed449e95ae59b909c25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

The following changes are made for Unity Netcode support:

- Added a `NetcodeMultiplayer` script to manage Netcode functionalities.
- Set lobby ID for the host and send it to clients upon connection, including it as a session property.
- Implemented connection and disconnection events for clients and the host using `OnClientConnectedCallback()` and `OnClientDisconnectCallback()`.
- Recorded the number of connected players through `SetConnectedCountServerRPC()` whenever connection or disconnection callbacks are triggered.
- Configured session properties for client ID, server address, and port with `SetMultiplayerSessionProperties()`.
- Added Netcode support option into the multiplayer page of project settings.
- Developed logic to add Netcode-related support scripts when the option is enabled.
- Added a validation check for the Network Manager in the scene
- Implemented async wait logic to locate the Network Manager if it's not present in the initial scene
- Added an RTT/Ping sensor

Height Task ID(s) (If applicable): https://c3d.height.app/T-5925

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
