### PR TITLE
Fix for Empty Lines in Local Cache

### DIFF
--- a/Editor/EditorDataUploader.cs
+++ b/Editor/EditorDataUploader.cs
@@ -31,7 +31,7 @@ namespace Cognitive3D
 				string content = string.Empty;
 				if (cacheSource.PeekContent(ref destination, ref content))
 				{
-					if (!string.IsNullOrEmpty(destination))
+					if (!string.IsNullOrEmpty(destination) && !string.IsNullOrEmpty(content))
 					{
 						//wait for post response
 						var bytes = System.Text.UTF8Encoding.UTF8.GetBytes(content);

--- a/Runtime/Internal/DualFileCache.cs
+++ b/Runtime/Internal/DualFileCache.cs
@@ -140,7 +140,7 @@ namespace Cognitive3D
             return i / 2;
         }
 
-        //manually keep track of how many write batches there are, instead of constantly opening/closing file streams
+        //manually keep track of how many write batches there are, instead of constantly opening/closing filestreams
         int numberWriteBatches = 0;
 
         public bool PeekContent(ref string Destination, ref string body)


### PR DESCRIPTION
# Description
This PR introduces changes to improve handling of empty lines and ensures valid content is read and written in the data files:

- Updated `MergeDataFiles()` to skip empty or whitespace-only lines when merging data from the write file into the read file.
- Improved `PeekContent()` to retry reading content after merging data files and return valid non-empty lines, with improved error handling for missing or invalid data.
- Added null checks for destination and content in `EditorDataUploader.cs`.

Height Task ID(s) (If applicable): https://c3d.height.app/T-8311

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
