### PR TITLE
Wave Eye Tracking Support Improvement

### DIFF
--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -551,9 +551,9 @@ namespace Cognitive3D
             );
 
             ProjectValidation.AddItem(
-                level: ProjectValidation.ItemLevel.Recommended, 
+                level: ProjectValidation.ItemLevel.Required, 
                 category: CATEGORY,
-                actionType: ProjectValidation.ItemAction.Apply,
+                actionType: ProjectValidation.ItemAction.Fix,
                 message: "No Eye Manager found in current scene.",
                 fixmessage: "Eye Manager found in current scene.",
                 checkAction: () =>

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -545,8 +545,26 @@ namespace Cognitive3D
                 fixAction: () =>
                 {
                     var waverig = new GameObject();
-                    waverig.name = "Wave Rig";
+                    waverig.name = "WaveRig";
                     waverig.AddComponent<Wave.Essence.WaveRig>();
+                }
+            );
+
+            ProjectValidation.AddItem(
+                level: ProjectValidation.ItemLevel.Recommended, 
+                category: CATEGORY,
+                actionType: ProjectValidation.ItemAction.Apply,
+                message: "No Eye Manager found in current scene.",
+                fixmessage: "Eye Manager found in current scene.",
+                checkAction: () =>
+                {   
+                    return ProjectValidation.FindComponentInActiveScene<Wave.Essence.Eye.EyeManager>();
+                },
+                fixAction: () =>
+                {
+                    var eyeManager = new GameObject();
+                    eyeManager.name = "EyeManager";
+                    eyeManager.AddComponent<Wave.Essence.Eye.EyeManager>();
                 }
             );
 

--- a/Runtime/Scripts/FixationRecorder.cs
+++ b/Runtime/Scripts/FixationRecorder.cs
@@ -606,6 +606,9 @@ namespace Cognitive3D
             
             if (Wave.Essence.Eye.EyeManager.Instance.GetCombindedEyeDirectionNormalized(out lastDirection) && Wave.Essence.Eye.EyeManager.Instance.GetCombinedEyeOrigin(out originPoint))
             {
+                originPoint = GameplayReferences.HMD.TransformPoint(originPoint);
+                lastDirection = GameplayReferences.HMD.TransformDirection(lastDirection);
+
                 ray = new Ray(originPoint, lastDirection);
                 return true;
             }

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -150,6 +150,7 @@ namespace Cognitive3D
         static Vector3 GetLookDirection()
         {
             Wave.Essence.Eye.EyeManager.Instance.GetCombindedEyeDirectionNormalized(out lastDirection);
+            lastDirection = GameplayReferences.HMD.TransformDirection(lastDirection);
             return lastDirection;
         }
 #elif C3D_OCULUS


### PR DESCRIPTION
# Description

Here are the updates made to improve eye tracking for the Wave SDK:

- Fixed the snap turning bug where the rig rotation wasn't considered. This was addressed in both `FixationRecorder.cs` and `GazeHelper.cs` by transforming the eye point from local space to world space.
- Added a new "required" validation item to check the eye manager component in the scene.

Height Task ID(s) (If applicable): https://c3d.height.app/T-9088

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
