### PR TITLE
Minor Bug Fixes

### DIFF
--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -755,7 +755,7 @@ namespace Cognitive3D
             }
     #endif
 
-    #if COGNITIVE3D_INCLUDE_OPENXR_1_9_0_OR_NEWER
+    #if COGNITIVE3D_INCLUDE_OPENXR_1_9_0_OR_NEWER && UNITY_ANDROID
             var androidOpenXRSettings = OpenXRSettings.GetSettingsForBuildTargetGroup(BuildTargetGroup.Android);
             var questFeature = androidOpenXRSettings.GetFeature<MetaQuestFeature>();
 
@@ -786,7 +786,7 @@ namespace Cognitive3D
             }
     #endif
 
-    #if COGNITIVE3D_INCLUDE_OPENXR_1_8_1_OR_1_8_2
+    #if COGNITIVE3D_INCLUDE_OPENXR_1_8_1_OR_1_8_2 && UNITY_ANDROID
             var androidOpenXRSettings = OpenXRSettings.GetSettingsForBuildTargetGroup(BuildTargetGroup.Android);
             var questFeature = androidOpenXRSettings.GetFeature<MetaQuestFeature>();
 

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -265,19 +265,28 @@ namespace Cognitive3D
                 level: ProjectValidation.ItemLevel.Required, 
                 category: CATEGORY,
                 actionType: ProjectValidation.ItemAction.Edit,
-                message: "Current scene path is invalid. Please verify the path in Cognitive3D's preference scene settings",
-                fixmessage: "Current scene path is valid",
+                message: "Scene path(s) are invalid. Please verify the path in Cognitive3D's preference scene settings",
+                fixmessage: "Scene path(s) are valid",
                 checkAction: () =>
                 {
-                    Cognitive3D_Preferences.SceneSettings c3dScene = Cognitive3D_Preferences.FindCurrentScene();
-                    if (c3dScene != null)
+                    const string oldMessage = "Scene path(s) are invalid. Please verify the path in Cognitive3D's preference scene settings";
+                    var invalidScenes = new List<string>();
+
+                    foreach (var scene in Cognitive3D_Preferences.Instance.sceneSettings)
                     {
-                        // Load the asset at the C3D scene path
-                        Object scene = AssetDatabase.LoadAssetAtPath(c3dScene.ScenePath, typeof(SceneAsset));
-                        return scene != null;
+                        if (AssetDatabase.LoadAssetAtPath(scene.ScenePath, typeof(SceneAsset)) == null)
+                        {
+                            invalidScenes.Add(scene.SceneName);
+                        }
                     }
-                    
-                    return false;
+
+                    string newMessage = invalidScenes.Count > 0 
+                        ? $"{string.Join(", ", invalidScenes)} {oldMessage}" 
+                        : oldMessage;
+
+                    ProjectValidation.UpdateItemMessage(oldMessage, newMessage);
+
+                    return invalidScenes.Count == 0;
                 },
                 fixAction: () =>
                 {
@@ -295,18 +304,19 @@ namespace Cognitive3D
                 {
                     string newMessage;
                     string oldMessage = "The maximum limit of controllers in the scene has been exceeded. Please remove any extra controller dynamic objects.";
-                    if (ProjectValidation.TryGetControllers(out var _controllerNamesList))
-                    {
-                        if (_controllerNamesList.Count > 2)
-                        {
-                            newMessage = oldMessage + $" The detected controller objects are: {string.Join(", ", _controllerNamesList)}";
-                            ProjectValidation.UpdateItemMessage(oldMessage, newMessage);
-                        }
 
-                        return _controllerNamesList.Count <= 2;
+                    if (ProjectValidation.TryGetControllers(out var controllerNamesList))
+                    {
+                        if (controllerNamesList.Count > 2)
+                        {
+                            newMessage = $"{oldMessage} The detected controller objects are: {string.Join(", ", controllerNamesList)}";
+                            ProjectValidation.UpdateItemMessage(oldMessage, newMessage);
+                            return false; // Exceeds the limit
+                        }
+                        return true; // Within the limit
                     }
-                    
-                    return true;
+
+                    return true; // No controllers detected or within the limit
                 },
                 fixAction: () =>
                 {

--- a/Editor/ProjectValidation/ProjectValidation.cs
+++ b/Editor/ProjectValidation/ProjectValidation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
+using System.Threading.Tasks;
 
 namespace Cognitive3D
 {
@@ -185,16 +186,21 @@ namespace Cognitive3D
         /// </summary>
         /// <param name="oldmessage">The message to search for in the validation items</param>
         /// <param name="newmessage">The new message to replace the old message with</param>
-        public static void UpdateItemMessage(string oldmessage, string newmessage)
+        internal static async void UpdateItemMessage(string oldMessage, string newMessage)
         {
-            var items = registry.GetAllItems();
-            foreach (var item in items)
+            foreach (var item in registry.GetAllItems())
             {
-                if (item.message.Contains(oldmessage))
+                if (item.message.Contains(oldMessage))
                 {
-                    item.message = newmessage;
+                    item.message = newMessage;
                 }
             }
+
+            // Add a brief delay to ensure updates are processed
+            await Task.Delay(600);
+
+            // Trigger the GUI update
+            ProjectValidationGUI.UpdateItemLevelMessage(oldMessage, newMessage);
         }
 
         /// <summary>

--- a/Editor/ProjectValidation/ProjectValidationGUI.cs
+++ b/Editor/ProjectValidation/ProjectValidationGUI.cs
@@ -235,6 +235,20 @@ namespace Cognitive3D
             FoldableList newLevelItemList = new FoldableList(title, icon, items);
             foldableLists.Add(newLevelItemList);
         }
+
+        internal static void UpdateItemLevelMessage(string oldMessage, string newMessage)
+        {
+            foreach (var itemList in foldableLists)
+            {
+                foreach (var item in itemList.items)
+                {
+                    if (item.message.Contains(oldMessage))
+                    {
+                        item.message = newMessage;
+                    }
+                }
+            }
+        }
     }
 
     [Serializable]

--- a/Runtime/Components/HMDPresentEvent.cs
+++ b/Runtime/Components/HMDPresentEvent.cs
@@ -102,8 +102,11 @@ namespace Cognitive3D.Components
                     if (isUserCurrentlyPresent && !wasUserPresentPreviously) // put on headset after removing
                     {
                         double currentTimestamp = Util.Timestamp();
-                        CustomEvent equippedEvent = new CustomEvent("c3d.User equipped headset").SetProperty("Seconds headset was removed", currentTimestamp - removedTimestamp);
-                        equippedEvent.Send();
+                        if (removedTimestamp.HasValue && currentTimestamp > removedTimestamp)
+                        {
+                            CustomEvent equippedEvent = new CustomEvent("c3d.User equipped headset").SetProperty("Seconds headset was removed", currentTimestamp - removedTimestamp);
+                            equippedEvent.Send();
+                        }
                         wasUserPresentPreviously = true;
                     }
                     else if (!isUserCurrentlyPresent && wasUserPresentPreviously) // removing headset

--- a/Runtime/Internal/GazeCore.cs
+++ b/Runtime/Internal/GazeCore.cs
@@ -46,6 +46,12 @@ namespace Cognitive3D
         static Transform cameraRoot;
         internal static bool GetFloorPosition(ref Vector3 floorPos)
         {
+            if (Cognitive3D_Manager.Instance.trackingSpace!= null)
+            {
+                floorPos = Cognitive3D_Manager.Instance.trackingSpace.position;
+                return true;
+            }
+            
             if (Cognitive3D_Preferences.Instance.RecordFloorPosition)
             {
                 if (cameraRoot == null)

--- a/Runtime/Internal/GazeCore.cs
+++ b/Runtime/Internal/GazeCore.cs
@@ -46,14 +46,14 @@ namespace Cognitive3D
         static Transform cameraRoot;
         internal static bool GetFloorPosition(ref Vector3 floorPos)
         {
-            if (Cognitive3D_Manager.Instance.trackingSpace!= null)
-            {
-                floorPos = Cognitive3D_Manager.Instance.trackingSpace.position;
-                return true;
-            }
-            
             if (Cognitive3D_Preferences.Instance.RecordFloorPosition)
             {
+                if (Cognitive3D_Manager.Instance.trackingSpace!= null)
+                {
+                    floorPos = Cognitive3D_Manager.Instance.trackingSpace.position;
+                    return true;
+                }
+                
                 if (cameraRoot == null)
                 {
                     cameraRoot = GameplayReferences.HMD.root;


### PR DESCRIPTION
# Description

This PR addresses several minor bugs:

- Updated `GetFloorPosition()` to use the tracking space position for the floor position. It falls back to a raycast if no tracking space is found in the scene.
- Added a value check for `removedTimestamp` in `CheckUserPresence()` to fix the null reference exception at runtime.
- Added a validation item for invalid scene paths which checks for invalid paths in any opened active scene.
- Added `UNITY_ANDROID` condition to two validation items to fix the compiler error where the Android module is not installed in the Unity editor

Height Task ID(s) (If applicable):
https://c3d.height.app/T-9252
https://c3d.height.app/T-10451
https://c3d.height.app/T-10627

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
