### PR TITLE
Support for Wave SDK Boundary

### DIFF
--- a/Runtime/Components/Boundary.cs
+++ b/Runtime/Components/Boundary.cs
@@ -9,7 +9,7 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Boundary")]
     public class Boundary : AnalyticsComponentBase
     {
-#if (C3D_OCULUS || C3D_DEFAULT) && UNITY_ANDROID && !UNITY_EDITOR
+#if (C3D_OCULUS || C3D_DEFAULT || C3D_VIVEWAVE) && UNITY_ANDROID && !UNITY_EDITOR
         /// <summary>
         /// The previous list of coordinates (local to tracking space) describing the boundary <br/>
         /// Used for comparison to determine if the boundary changed

--- a/Runtime/Components/Boundary.cs
+++ b/Runtime/Components/Boundary.cs
@@ -141,7 +141,7 @@ namespace Cognitive3D.Components
 #region Inspector Utils
         public override bool GetWarning()
         {
-#if C3D_OCULUS || C3D_DEFAULT
+#if C3D_OCULUS || C3D_DEFAULT || C3D_VIVEWAVE
             return false;
 #else
             return true;
@@ -150,10 +150,10 @@ namespace Cognitive3D.Components
 
         public override string GetDescription()
         {
-#if C3D_OCULUS || C3D_DEFAULT
+#if C3D_OCULUS || C3D_DEFAULT || C3D_VIVEWAVE
             return "Records player boundary";
 #else
-            return "Current platform does not support this component. This component is only supported for Meta and OpenXR.";
+            return "Current platform does not support this component. This component is only supported for Meta, HTC Wave, and OpenXR.";
 #endif
         }
 #endregion

--- a/Runtime/Internal/BoundaryUtil.cs
+++ b/Runtime/Internal/BoundaryUtil.cs
@@ -74,6 +74,21 @@ namespace Cognitive3D.Components
             {
                 return null;
             }
+#elif C3D_VIVEWAVE
+            float width = Wave.Native.Interop.WVR_GetArena().area.rectangle.width;
+            float length = Wave.Native.Interop.WVR_GetArena().area.rectangle.length;
+
+            // Half dimensions
+            float halfWidth = width / 2f;
+            float halfLength = length / 2f;
+
+            // 4 corner points (clockwise or counter-clockwise)
+            Vector3[] boundaryCorners = new Vector3[4];
+            boundaryCorners[0] = new Vector3(-halfWidth, 0, -halfLength); // Bottom left
+            boundaryCorners[1] = new Vector3(halfWidth, 0, -halfLength);  // Bottom right
+            boundaryCorners[2] = new Vector3(halfWidth, 0, halfLength);   // Top right
+            boundaryCorners[3] = new Vector3(-halfWidth, 0, halfLength);  // Top left
+            return boundaryCorners;
 #else
             // Using Unity's XRInputSubsystem as fallback
             List<XRInputSubsystem> subsystems = new List<XRInputSubsystem>();
@@ -83,7 +98,7 @@ namespace Cognitive3D.Components
             SubsystemManager.GetInstances<XRInputSubsystem>(subsystems);
 #endif
 
-            // Handling case of multiple subsystems to find the first one that "works"
+            // Handling case of multiple subsystems to find the first one that retrieves boundary points
             foreach (XRInputSubsystem subsystem in subsystems)
             {
                 if (!subsystem.running)
@@ -96,8 +111,6 @@ namespace Cognitive3D.Components
                     return retrievedPoints.ToArray();
                 }
             }
-            // Unable to find boundary points - should we send an event?
-            // Probably will return empty list; need to append with warning or somethings
             Util.LogOnce("Unable to find boundary points using XRInputSubsystem", LogType.Warning);
             return null;
 #endif
@@ -129,6 +142,11 @@ namespace Cognitive3D.Components
             return result;
         }
 
+        /// <summary>
+        /// Retrieves tracking space data
+        /// </summary>
+        /// <param name="customTransform"></param>
+        /// <returns></returns>
         internal static bool TryGetTrackingSpaceTransform(out CustomTransform customTransform)
         {
             customTransform = null;


### PR DESCRIPTION
# Description

The following changes are made for boundary handling with the Wave SDK:

- Implemented logic to retrieve the four boundary corners using the Wave SDK by calculating positions based on boundary width and length.
- Added `C3D_VIVEWAVE` define in `Boundary.cs` to enable Wave SDK-specific boundary handling.

Height Task ID(s) (If applicable):

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
