### PR TITLE
Automatic SteamVR Controller Tracking

### DIFF
--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -2108,8 +2108,6 @@ namespace Cognitive3D
             {
                 if (LoadBindingFile(out var bindingfile, binding))
                 {
-                    Debug.LogError("Name is " + bindingfile.name);
-
                     if (bindingfile.bindings.ContainsKey("/actions/c3d_input"))
                     {
                         bindingfile.bindings.Remove("/actions/c3d_input");
@@ -2175,7 +2173,6 @@ namespace Cognitive3D
                         actionlist.sources.Add(createSource("button", "/user/hand/right/input/b", "click", "/actions/c3d_input/in/B"));
                     }
 
-                    Debug.LogError("Or here? " + actionlist.sources.Count);
                     bindingfile.bindings.Add("/actions/c3d_input", actionlist);
                     Util.logDevelopment($"SceneSetup.SetDefaultBindings has saved Cognitive3D input bindings for {binding}");
                     SaveBindingFile(bindingfile, binding);

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -1650,7 +1650,6 @@ namespace Cognitive3D
                     break;
                 case Page.PlayerSetup:
                     bool isSetupComplete = AllSetupComplete;
-                    bool needsConfirmation = false;
 
                     // Track setup completion
                     onclick += () =>
@@ -1660,6 +1659,7 @@ namespace Cognitive3D
                     };
 
 #if C3D_STEAMVR2
+                    bool needsConfirmation = false;
                     if (!isSetupComplete)
                     {
                         // Automatically append input bindings for SteamVR
@@ -2056,18 +2056,22 @@ namespace Cognitive3D
                 }
 
                 // Vive controller
-                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Grip", type = "boolean" });
-                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Trigger", type = "vector1" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Touchpad", type = "vector2" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Touchpad_Press", type = "boolean" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Touchpad_Touch", type = "boolean" });
-                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Menu", type = "boolean" });
 
                 // Oculus controller
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/A", type = "boolean" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/B", type = "boolean" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/X", type = "boolean" });
                 actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Y", type = "boolean" });
+                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Joystick", type = "vector2" });
+
+                // Common
+                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Menu", type = "boolean" });
+                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Grip", type = "vector1" });
+                actionfile.actions.Add(new SteamVR_Input_ActionFile_Action() { name = "/actions/C3D_Input/in/Trigger", type = "vector1" });
+
                 actionfile.action_sets.Add(cognitiveActionSet);
 
                 SaveActionFile(actionfile);
@@ -2117,14 +2121,17 @@ namespace Cognitive3D
 
                     if (bindingfile.name.Contains("vive_controller"))
                     {
-                        actionlist.sources.Add(createSource("button", "/user/hand/left/input/grip", "click", "/actions/c3d_input/in/grip"));
-                        actionlist.sources.Add(createSource("button", "/user/hand/right/input/grip", "click", "/actions/c3d_input/in/grip"));
+                        // Grip (vector1)
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/left/input/grip", "pull", "/actions/c3d_input/in/Grip"));
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/right/input/grip", "pull", "/actions/c3d_input/in/Grip"));
 
-                        actionlist.sources.Add(createSource("button", "/user/hand/left/input/menu", "click", "/actions/c3d_input/in/menu"));
-                        actionlist.sources.Add(createSource("button", "/user/hand/right/input/menu", "click", "/actions/c3d_input/in/menu"));
+                        // Trigger (vector1)
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/left/input/trigger", "pull", "/actions/c3d_input/in/Trigger"));
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/right/input/trigger", "pull", "/actions/c3d_input/in/Trigger"));
 
-                        actionlist.sources.Add(createSource("trigger", "/user/hand/left/input/trigger", "pull", "/actions/c3d_input/in/trigger"));
-                        actionlist.sources.Add(createSource("trigger", "/user/hand/right/input/trigger", "pull", "/actions/c3d_input/in/trigger"));
+                        // Menu (boolean)
+                        actionlist.sources.Add(createSource("button", "/user/hand/left/input/menu", "click", "/actions/c3d_input/in/Menu"));
+                        actionlist.sources.Add(createSource("button", "/user/hand/right/input/menu", "click", "/actions/c3d_input/in/Menu"));
 
                         //left touchpad
                         SteamVR_Input_BindingFile_Source bindingSource_left_pad = new SteamVR_Input_BindingFile_Source();
@@ -2166,11 +2173,29 @@ namespace Cognitive3D
                     }
                     else if (bindingfile.name.Contains("oculus_touch"))
                     {
+                        // Primary Buttons
                         actionlist.sources.Add(createSource("button", "/user/hand/left/input/x", "click", "/actions/c3d_input/in/X"));
                         actionlist.sources.Add(createSource("button", "/user/hand/right/input/a", "click", "/actions/c3d_input/in/A"));
 
+                        // Secondary Buttons
                         actionlist.sources.Add(createSource("button", "/user/hand/left/input/y", "click", "/actions/c3d_input/in/Y"));
                         actionlist.sources.Add(createSource("button", "/user/hand/right/input/b", "click", "/actions/c3d_input/in/B"));
+
+                        // Grip (vector1)
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/left/input/grip", "pull", "/actions/c3d_input/in/Grip"));
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/right/input/grip", "pull", "/actions/c3d_input/in/Grip"));
+
+                        // Trigger (vector1)
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/left/input/trigger", "pull", "/actions/c3d_input/in/Trigger"));
+                        actionlist.sources.Add(createSource("trigger", "/user/hand/right/input/trigger", "pull", "/actions/c3d_input/in/Trigger"));
+
+                        // Menu (boolean)
+                        actionlist.sources.Add(createSource("button", "/user/hand/left/input/menu", "click", "/actions/c3d_input/in/Menu"));
+                        actionlist.sources.Add(createSource("button", "/user/hand/right/input/menu", "click", "/actions/c3d_input/in/Menu"));
+
+                        // Joystick (vector2)
+                        actionlist.sources.Add(createJoystickSource("/user/hand/left/input/joystick", "/actions/c3d_input/in/Joystick"));
+                        actionlist.sources.Add(createJoystickSource("/user/hand/right/input/joystick", "/actions/c3d_input/in/Joystick"));
                     }
 
                     bindingfile.bindings.Add("/actions/c3d_input", actionlist);
@@ -2185,17 +2210,40 @@ namespace Cognitive3D
         }
 
         //mode = button, path = "/user/hand/left/input/grip", actiontype = "click", action = "/actions/c3d_input/in/grip"
-        static SteamVR_Input_BindingFile_Source createSource(string mode, string path, string actiontype, string action)
-        {
-            SteamVR_Input_BindingFile_Source bindingSource = new SteamVR_Input_BindingFile_Source();
-            bindingSource.mode = mode;
-            bindingSource.path = path;
 
-            SteamVR_Input_BindingFile_Source_Input_StringDictionary stringDictionary = new SteamVR_Input_BindingFile_Source_Input_StringDictionary();
-            stringDictionary.Add("output", action);
-            bindingSource.inputs.Add(actiontype, stringDictionary);
+        static SteamVR_Input_BindingFile_Source createSource(string mode, string path, string inputType, string action)
+        {
+            var bindingSource = new SteamVR_Input_BindingFile_Source
+            {
+                mode = mode,
+                path = path
+            };
+
+            var inputMap = new SteamVR_Input_BindingFile_Source_Input_StringDictionary
+            {
+                { "output", action }
+            };
+
+            bindingSource.inputs.Add(inputType, inputMap);
 
             return bindingSource;
+        }
+
+        static SteamVR_Input_BindingFile_Source createJoystickSource(string path, string action)
+        {
+            var source = new SteamVR_Input_BindingFile_Source
+            {
+                mode = "joystick",
+                path = path
+            };
+
+            var positionMap = new SteamVR_Input_BindingFile_Source_Input_StringDictionary
+            {
+                { "output", action }
+            };
+
+            source.inputs.Add("position", positionMap);
+            return source;
         }
 
         static bool LoadBindingFile(out SteamVR_Input_BindingFile bindingfile, string bindingFileName)

--- a/Editor/SceneSetupWindow.cs
+++ b/Editor/SceneSetupWindow.cs
@@ -617,7 +617,7 @@ namespace Cognitive3D
                             }
                         }
                     }
-                    
+
                     var trackingSpaces = FindObjectsOfType<RoomTrackingSpace>();
                     if (trackingSpaces.Length > 0)
                     {
@@ -688,17 +688,21 @@ namespace Cognitive3D
 
                 //right hand label
                 DrawObjectPicker(ref rightcontroller, "Right Controller", 390, 5689469);
-                HandleDragAndDrop(new Rect(180, 390, 440, 30), ref rightcontroller); 
+                HandleDragAndDrop(new Rect(180, 390, 440, 30), ref rightcontroller);
 
                 if (!rightControllerIsValid)
                 {
                     GUI.Label(new Rect(400, 390, 30, 30), new GUIContent(EditorCore.Alert, "Right Controller not set"), "image_centered");
                 }
 
-                AllSetupComplete = (Cognitive3D_Manager.autoInitializePlayerSetup || (leftControllerIsValid && rightControllerIsValid)) 
+                AllSetupComplete = (Cognitive3D_Manager.autoInitializePlayerSetup || (leftControllerIsValid && rightControllerIsValid))
                                 && cameraIsValid && trackingSpaceIsValid;
 
-                if (GUI.Button(new Rect(160, 440, 200, 30), new GUIContent("Set up GameObjects","Set up the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
+#if C3D_STEAMVR2
+                if (GUI.Button(new Rect(30, 440, 200, 30), new GUIContent("Set up GameObjects", "Set up the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
+#else
+                if (GUI.Button(new Rect(160, 440, 200, 30), new GUIContent("Set up GameObjects", "Set up the player rig tracking space, attach Dynamic Object components to the controllers, and configures controllers to record button inputs")))
+#endif
                 {
                     if (mainCameraObject != null)
                     {
@@ -713,48 +717,55 @@ namespace Cognitive3D
 
                 if (AllSetupComplete)
                 {
+#if C3D_STEAMVR2
+                    GUI.Label(new Rect(0, 440, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+#else
                     GUI.Label(new Rect(130, 440, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+#endif
                 }
                 else
                 {
-                    GUI.Label(new Rect(128, 440, 32, 32), EditorCore.Alert, "image_centered");
-                }
-            }
 #if C3D_STEAMVR2
-
-            //generate default input file if it doesn't already exist
-            bool hasInputActionFile = SteamVR_Input.DoesActionsFileExist();
-            if (GUI.Button(new Rect(160, 445, 200, 30), "Append Input Bindings"))
-            {
-                if (SteamVR_Input.actionFile == null)
-                {
-                    bool initializeSuccess = SteamVR_Input.InitializeFile(false, false);
-
-                    if (initializeSuccess == false)
-                    {
-                        //copy
-                        SteamVR_CopyExampleInputFiles.CopyFiles(true);
-                        System.Threading.Thread.Sleep(1000);
-                        SteamVR_Input.InitializeFile();
-                    }
-                }
-                if (SteamVR_Input_EditorWindow.IsOpen())
-                {
-                    SteamVR_Input_EditorWindow.GetOpenWindow().Close();
-                }
-                AppendSteamVRActionSet();
-                SetDefaultBindings();
-                Valve.VR.SteamVR_Input_Generator.BeginGeneration();
-            }
-            if (DoesC3DInputActionSetExist())
-            {
-                GUI.Label(new Rect(130, 445, 30, 30), EditorCore.CircleCheckmark, "image_centered");
-            }
-            else
-            {
-                GUI.Label(new Rect(128, 445, 32, 32), EditorCore.Alert, "image_centered");
-            }
+                    GUI.Label(new Rect(0, 440, 32, 32), EditorCore.Alert, "image_centered");
+#else
+                    GUI.Label(new Rect(128, 440, 32, 32), EditorCore.Alert, "image_centered");
 #endif
+                }
+#if C3D_STEAMVR2
+                //generate default input file if it doesn't already exist
+                bool hasInputActionFile = SteamVR_Input.DoesActionsFileExist();
+                if (GUI.Button(new Rect(270, 440, 200, 30), "Append Input Bindings"))
+                {
+                    if (SteamVR_Input.actionFile == null)
+                    {
+                        bool initializeSuccess = SteamVR_Input.InitializeFile(false, false);
+
+                        if (initializeSuccess == false)
+                        {
+                            //copy
+                            SteamVR_CopyExampleInputFiles.CopyFiles(true);
+                            System.Threading.Thread.Sleep(1000);
+                            SteamVR_Input.InitializeFile();
+                        }
+                    }
+                    if (SteamVR_Input_EditorWindow.IsOpen())
+                    {
+                        SteamVR_Input_EditorWindow.GetOpenWindow().Close();
+                    }
+                    AppendSteamVRActionSet();
+                    SetDefaultBindings();
+                    Valve.VR.SteamVR_Input_Generator.BeginGeneration();
+                }
+                if (DoesC3DInputActionSetExist())
+                {
+                    GUI.Label(new Rect(240, 440, 30, 30), EditorCore.CircleCheckmark, "image_centered");
+                }
+                else
+                {
+                    GUI.Label(new Rect(238, 440, 32, 32), EditorCore.Alert, "image_centered");
+                }
+#endif
+            }
         }
 
         private void DrawObjectPicker(ref GameObject obj, string label, int rectHeight, int pickerID)
@@ -1665,26 +1676,38 @@ namespace Cognitive3D
                         onclick += () => SegmentAnalytics.TrackEvent("PlayerGOIncomplete_PlayerSetupPage", "SceneSetupPlayerSetupPage");
                     }
 #if C3D_STEAMVR2
-                    appearDisabled = !AllSetupComplete;
                     if (!AllSetupComplete)
                     {
+                        appearDisabled = !Cognitive3D_Manager.autoInitializePlayerSetup;
+
                         if (appearDisabled)
                         {
-                            onclick += () => { if (EditorUtility.DisplayDialog("Continue", "Are you sure you want to continue without configuring the player prefab?", "Yes", "No")) { currentPage++; } };
+                            onclick += () =>
+                            {
+                                if (EditorUtility.DisplayDialog("Continue", 
+                                    "Are you sure you want to continue without configuring the player prefab?", "Yes", "No"))
+                                {
+                                    currentPage++;
+                                }
+                            };
                         }
                     }
                     else
                     {
                         appearDisabled = !hasFoundSteamVRActionSet;
-                        if (!hasFoundSteamVRActionSet)
+
+                        if (appearDisabled)
                         {
-                            if (appearDisabled)
+                            onclick += () =>
                             {
-                                onclick += () => { if (EditorUtility.DisplayDialog("Continue", "Are you sure you want to continue without creating the necessary SteamVR Input Action Set files?", "Yes", "No")) { currentPage++; } };
-                            }
+                                if (EditorUtility.DisplayDialog("Continue", 
+                                    "Are you sure you want to continue without creating the necessary SteamVR Input Action Set files?", "Yes", "No"))
+                                {
+                                    currentPage++;
+                                }
+                            };
                         }
                     }
-
 #else
                     appearDisabled = !AllSetupComplete && !Cognitive3D_Manager.autoInitializePlayerSetup;
                     if (appearDisabled)

--- a/Runtime/Components/ControllerInputTracker.cs
+++ b/Runtime/Components/ControllerInputTracker.cs
@@ -337,7 +337,6 @@ namespace Cognitive3D.Components
                 ? CurrentRightButtonStates
                 : CurrentLeftButtonStates;
 
-            Debug.LogError($"Button name: {internalButtonName}, state: {newState}, target: {targetStateDict}");
             OnButtonChanged(internalButtonName, newState, targetStateDict);
         }
 
@@ -362,13 +361,6 @@ namespace Cognitive3D.Components
                 ? CurrentRightButtonStates
                 : CurrentLeftButtonStates;
 
-            Vector2 axis = Vector2.zero;
-            if (fromAction != null && fromAction.GetType() == typeof(SteamVR_Action_Single))
-            {
-                axis = lastAxis;
-            }
-
-            Debug.LogError($"Button name: {internalButtonName}, percent: {percent}, axis: {axis}, target: {targetStateDict}");
             OnSingleChanged(internalButtonName, percent, targetStateDict);
 
             TouchForce = percent;
@@ -394,7 +386,6 @@ namespace Cognitive3D.Components
                 ? CurrentRightButtonStates
                 : CurrentLeftButtonStates;
 
-            Debug.LogError($"Button name: {internalButtonName}, percent: {percent}, axis: {axis}, target: {targetStateDict}");
             OnVectorChanged(internalButtonName, percent, axis.x, axis.y, targetStateDict);
 
             lastAxis = axis;

--- a/Runtime/Components/ControllerTracking.cs
+++ b/Runtime/Components/ControllerTracking.cs
@@ -13,7 +13,7 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Controller Tracking")]
     public class ControllerTracking : AnalyticsComponentBase
     {
-        public InputUtil.ControllerType FallbackControllerType = (InputUtil.ControllerType)3;
+        public InputUtil.ControllerType FallbackControllerType;
 
         private readonly float ControllerTrackingInterval = 1;
 

--- a/Runtime/Components/ControllerTracking.cs
+++ b/Runtime/Components/ControllerTracking.cs
@@ -13,6 +13,8 @@ namespace Cognitive3D.Components
     [AddComponentMenu("Cognitive3D/Components/Controller Tracking")]
     public class ControllerTracking : AnalyticsComponentBase
     {
+        public InputUtil.ControllerType FallbackControllerType = (InputUtil.ControllerType)3;
+
         private readonly float ControllerTrackingInterval = 1;
 
         /// <summary>
@@ -132,14 +134,14 @@ namespace Cognitive3D.Components
             // Check if the left controller is valid and not yet registered
             if (!leftControllerRegistered && InputUtil.TryGetInputDevice(XRNode.LeftHand, out InputDevice leftController))
             {
-                DynamicManager.RegisterController(XRNode.LeftHand, false);
+                DynamicManager.RegisterController(XRNode.LeftHand, false, FallbackControllerType);
                 leftControllerRegistered = true;
             }
 
             // Check if the right controller is valid and not yet registered
             if (!rightControllerRegistered && InputUtil.TryGetInputDevice(XRNode.RightHand, out InputDevice rightController))
             {
-                DynamicManager.RegisterController(XRNode.RightHand, true);
+                DynamicManager.RegisterController(XRNode.RightHand, true, FallbackControllerType);
                 rightControllerRegistered = true;
             }
 

--- a/Runtime/Internal/DynamicManager.cs
+++ b/Runtime/Internal/DynamicManager.cs
@@ -357,7 +357,7 @@ namespace Cognitive3D
 #region Controllers and Hands Manager
         private static DynamicData[] ActiveInputsArray = new DynamicData[24];
 
-        internal static void RegisterController(XRNode controller, bool isRight, string registerId = "")
+        internal static void RegisterController(XRNode controller, bool isRight, InputUtil.ControllerType displayTypeFallback, string registerId = "")
         {
             InputUtil.TryGetInputDevice(controller, out InputDevice controllerDevice);
             InputUtil.TryGetControllerPosition(controller, out Vector3 pos);
@@ -365,6 +365,12 @@ namespace Cognitive3D
 
             var controllerDisplayType = InputUtil.GetControllerPopupName(controllerDevice.name, isRight);
             var commonDynamicMesh = InputUtil.GetControllerMeshName(controllerDevice.name, isRight);
+
+            if (controllerDisplayType == InputUtil.ControllerDisplayType.unknown || commonDynamicMesh == InputUtil.CommonDynamicMesh.Unknown)
+            {
+                InputUtil.SetControllerFromFallback(displayTypeFallback, isRight, out controllerDisplayType, out commonDynamicMesh);
+            }
+
             var registerMeshName = commonDynamicMesh.ToString();
             var data = new DynamicData(controllerDevice.name, registerId, registerMeshName, pos, rot, 0.01f, 0.1f, 0.1f, InputUtil.InputType.Controller.ToString(), controllerDisplayType.ToString(), isRight);
 

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -21,16 +21,16 @@ namespace Cognitive3D
         //developer facing high level controller type selection
         public enum ControllerType
         {
-            Quest2 = 1,
-            QuestPro = 2,
-            Quest3 = 9,
+            Quest2 = 0,
+            QuestPro = 1,
+            Quest3 = 2,
             ViveWand = 3,
             WindowsMRController = 4,
             SteamIndex = 5,
             PicoNeo3 = 6,
             PicoNeo4 = 7,
             ViveFocus = 8,
-            Hand = 10, //might suggest that this includes skeletal hand tracking, which needs some more design
+            Hand = 9, //might suggest that this includes skeletal hand tracking, which needs some more design
             //Generic = 0, //basically a non-branded oculus touch controller
         }
         

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -559,7 +559,7 @@ namespace Cognitive3D
         public static bool TryGetControllerPosition(XRNode node, out Vector3 position)
         {
             position = GetNodePosition(node);
-            if (GameplayReferences.HMD)
+            if (GameplayReferences.HMD && GameplayReferences.HMD.transform.parent)
             {
                 position = GameplayReferences.HMD.transform.parent.TransformPoint(position);
             }
@@ -659,7 +659,7 @@ namespace Cognitive3D
                 case InputType.Controller:
                     return GetDefaultNodePosition(node);
 
-    #if COGNITIVE3D_INCLUDE_XR_HANDS
+#if COGNITIVE3D_INCLUDE_XR_HANDS
                 case InputType.Hand:
                     var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
                     SubsystemManager.GetSubsystems(subsystems);
@@ -679,7 +679,7 @@ namespace Cognitive3D
                         }
                     }
                     break;
-    #endif
+#endif
             }
 #endif
             // Default fallback for retrieving controller positions
@@ -724,7 +724,7 @@ namespace Cognitive3D
                 return false;
             }
             
-            if (GameplayReferences.HMD)
+            if (GameplayReferences.HMD && GameplayReferences.HMD.transform.parent)
             {
                 rotation = GameplayReferences.HMD.transform.parent.rotation * rotation;
             }

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -317,6 +317,138 @@ namespace Cognitive3D
             controllerDisplayType = ControllerDisplayType.unknown;
             return false;
         }
+        
+        /// <summary>
+        /// Maps the given fallback controller type and handedness (left/right) to corresponding 
+        /// controller display type and dynamic mesh values. This provides a standardized representation 
+        /// of controllers when actual device data is unavailable or unrecognized.
+        /// </summary>
+        /// <param name="fallbackControllerType">The fallback controller type to use (e.g., Quest3, ViveWand).</param>
+        /// <param name="isRight">True if the controller is the right-hand controller; false for left.</param>
+        /// <param name="controllerDisplayType">Output parameter for the matching controller display type enum.</param>
+        /// <param name="commonDynamicMesh">Output parameter for the associated controller mesh enum.</param>
+        internal static void SetControllerFromFallback(ControllerType fallbackControllerType, bool isRight, out ControllerDisplayType controllerDisplayType, out CommonDynamicMesh commonDynamicMesh)
+        {
+            switch (fallbackControllerType)
+            {
+                case ControllerType.Quest2:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.oculus_quest_touch_right;
+                        commonDynamicMesh = CommonDynamicMesh.OculusQuestTouchRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.oculus_quest_touch_left;
+                        commonDynamicMesh = CommonDynamicMesh.OculusQuestTouchLeft;
+                    }
+                    break;
+                case ControllerType.QuestPro:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.quest_pro_touch_right;
+                        commonDynamicMesh = CommonDynamicMesh.QuestProTouchRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.quest_pro_touch_left;
+                        commonDynamicMesh = CommonDynamicMesh.QuestProTouchLeft;
+                    }
+                    break;
+                case ControllerType.Quest3:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.quest_plus_touch_right;
+                        commonDynamicMesh = CommonDynamicMesh.QuestPlusTouchRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.quest_plus_touch_left;
+                        commonDynamicMesh = CommonDynamicMesh.QuestPlusTouchLeft;
+                    }
+                    break;
+                case ControllerType.ViveWand:
+                    controllerDisplayType = ControllerDisplayType.vive_controller;
+                    commonDynamicMesh = CommonDynamicMesh.ViveController;
+                    break;
+                case ControllerType.WindowsMRController:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.windows_mixed_reality_controller_right;
+                        commonDynamicMesh = CommonDynamicMesh.WindowsMixedRealityRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.windows_mixed_reality_controller_left;
+                        commonDynamicMesh = CommonDynamicMesh.WindowsMixedRealityLeft;
+                    }
+                    break;
+                case ControllerType.SteamIndex:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.steam_index_right;
+                        commonDynamicMesh = CommonDynamicMesh.SteamIndexRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.steam_index_left;
+                        commonDynamicMesh = CommonDynamicMesh.SteamIndexLeft;
+                    }
+                    break;
+                case ControllerType.PicoNeo3:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.pico_neo_3_eye_controller_right;
+                        commonDynamicMesh = CommonDynamicMesh.PicoNeo3ControllerRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.pico_neo_3_eye_controller_left;
+                        commonDynamicMesh = CommonDynamicMesh.PicoNeo3ControllerLeft;
+                    }
+                    break;
+                case ControllerType.PicoNeo4:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.pico_neo_4_eye_controller_right;
+                        commonDynamicMesh = CommonDynamicMesh.PicoNeo4ControllerRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.pico_neo_4_eye_controller_left;
+                        commonDynamicMesh = CommonDynamicMesh.PicoNeo4ControllerLeft;
+                    }
+                    break;
+                case ControllerType.ViveFocus:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.vive_focus_controller_right;
+                        commonDynamicMesh = CommonDynamicMesh.ViveFocusControllerRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.vive_focus_controller_left;
+                        commonDynamicMesh = CommonDynamicMesh.ViveFocusControllerLeft;
+                    }
+                    break;
+                case ControllerType.Hand:
+                    if (isRight)
+                    {
+                        controllerDisplayType = ControllerDisplayType.hand_right;
+                        commonDynamicMesh = CommonDynamicMesh.handRight;
+                    }
+                    else
+                    {
+                        controllerDisplayType = ControllerDisplayType.hand_left;
+                        commonDynamicMesh = CommonDynamicMesh.handLeft;
+                    }
+                    break;
+                default:
+                    controllerDisplayType = ControllerDisplayType.unknown;
+                    commonDynamicMesh = CommonDynamicMesh.Unknown;
+                    break;
+            }
+        }
 
         /// <summary>
         /// Oculus SeGets the current tracked device i.e. hand or controller
@@ -500,27 +632,27 @@ namespace Cognitive3D
                     break;
             }
 #elif C3D_STEAMVR2
-            var rotation = Quaternion.identity;
+            var position = Vector3.zero;
             var system = Valve.VR.OpenVR.System;
             if (system == null)
-                return rotation;
+                return position;
 
             var role = node == XRNode.RightHand ? Valve.VR.ETrackedControllerRole.RightHand : Valve.VR.ETrackedControllerRole.LeftHand;
             var deviceIndex = system.GetTrackedDeviceIndexForControllerRole(role);
             if (deviceIndex == Valve.VR.OpenVR.k_unTrackedDeviceIndexInvalid)
-                return rotation;
+                return position;
             
             if (!Valve.VR.SteamVR.active || Valve.VR.OpenVR.Compositor == null)
             {
-                return rotation;
+                return position;
             }
 
             Valve.VR.OpenVR.Compositor.GetLastPoses(poses, gamePoses);
             var pose = poses[deviceIndex];
             if (!pose.bPoseIsValid)
-                return rotation;
+                return position;
 
-            rotation = pose.mDeviceToAbsoluteTracking.GetRotation();
+            position = pose.mDeviceToAbsoluteTracking.GetPosition();
 #elif C3D_DEFAULT
             switch (currentTracking)
             {
@@ -659,27 +791,27 @@ namespace Cognitive3D
                     break;
             }
 #elif C3D_STEAMVR2
-            var position = Vector3.zero;
+            var rotation = Quaternion.identity;
             var system = Valve.VR.OpenVR.System;
             if (system == null)
-                return position;
+                return rotation;
 
             var role = node == XRNode.RightHand ? Valve.VR.ETrackedControllerRole.RightHand : Valve.VR.ETrackedControllerRole.LeftHand;
             var deviceIndex = system.GetTrackedDeviceIndexForControllerRole(role);
             if (deviceIndex == Valve.VR.OpenVR.k_unTrackedDeviceIndexInvalid)
-                return position;
+                return rotation;
             
             if (!Valve.VR.SteamVR.active || Valve.VR.OpenVR.Compositor == null)
             {
-                return position;
+                return rotation;
             }
 
             Valve.VR.OpenVR.Compositor.GetLastPoses(poses, gamePoses);
             var pose = poses[deviceIndex];
             if (!pose.bPoseIsValid)
-                return position;
+                return rotation;
 
-            position = pose.mDeviceToAbsoluteTracking.GetPosition();
+            rotation = pose.mDeviceToAbsoluteTracking.GetRotation();
 #elif C3D_DEFAULT
             switch (currentTracking)
             {

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -126,7 +126,7 @@ namespace Cognitive3D
                     if (InputUtil.GetCurrentTrackedDevice() == InputUtil.InputType.Hand || InputUtil.GetCurrentTrackedDevice() == InputUtil.InputType.None)
                     {
                         // just quickly look up controller by type, isRight
-                        SetControllerFromFallback(FallbackControllerType, IsRight);
+                        InputUtil.SetControllerFromFallback(FallbackControllerType, IsRight, out controllerDisplayType, out commonDynamicMesh);
                         registerMeshName = commonDynamicMesh.ToString();
                         RegisterDynamicObject(registerMeshName);
                         return;
@@ -152,7 +152,7 @@ namespace Cognitive3D
                             commonDynamicMesh == InputUtil.CommonDynamicMesh.Unknown)
                         {
                             //failed to identify the controller - use the fallback
-                            SetControllerFromFallback(FallbackControllerType, IsRight);
+                            InputUtil.SetControllerFromFallback(FallbackControllerType, IsRight, out controllerDisplayType, out commonDynamicMesh);
                             registerMeshName = commonDynamicMesh.ToString();
                         }
                     }
@@ -160,7 +160,7 @@ namespace Cognitive3D
                 else
                 {
                     //just quickly look up controller by type, isRight
-                    SetControllerFromFallback(FallbackControllerType, IsRight);
+                    InputUtil.SetControllerFromFallback(FallbackControllerType, IsRight, out controllerDisplayType, out commonDynamicMesh);
                     registerMeshName = commonDynamicMesh.ToString();
                 }
             }
@@ -210,130 +210,6 @@ namespace Cognitive3D
             }
             mesh = commonDynamicMesh;
             display = controllerDisplayType;
-        }
-
-        //sets the class variables from the fallback controller type
-        private void SetControllerFromFallback(InputUtil.ControllerType fallbackControllerType, bool isRight)
-        {
-            switch (fallbackControllerType)
-            {
-                case InputUtil.ControllerType.Quest2:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.oculus_quest_touch_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.OculusQuestTouchRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.oculus_quest_touch_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.OculusQuestTouchLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.QuestPro:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.quest_pro_touch_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.QuestProTouchRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.quest_pro_touch_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.QuestProTouchLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.Quest3:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.quest_plus_touch_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.QuestPlusTouchRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.quest_plus_touch_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.QuestPlusTouchLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.ViveWand:
-                    controllerDisplayType = InputUtil.ControllerDisplayType.vive_controller;
-                    commonDynamicMesh = InputUtil.CommonDynamicMesh.ViveController;
-                    break;
-                case InputUtil.ControllerType.WindowsMRController:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.windows_mixed_reality_controller_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.WindowsMixedRealityRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.windows_mixed_reality_controller_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.WindowsMixedRealityLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.SteamIndex:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.steam_index_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.SteamIndexRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.steam_index_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.SteamIndexLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.PicoNeo3:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.pico_neo_3_eye_controller_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.PicoNeo3ControllerRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.pico_neo_3_eye_controller_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.PicoNeo3ControllerLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.PicoNeo4:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.pico_neo_4_eye_controller_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.PicoNeo4ControllerRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.pico_neo_4_eye_controller_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.PicoNeo4ControllerLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.ViveFocus:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.vive_focus_controller_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.ViveFocusControllerRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.vive_focus_controller_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.ViveFocusControllerLeft;
-                    }
-                    break;
-                case InputUtil.ControllerType.Hand:
-                    if (isRight)
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.hand_right;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.handRight;
-                    }
-                    else
-                    {
-                        controllerDisplayType = InputUtil.ControllerDisplayType.hand_left;
-                        commonDynamicMesh = InputUtil.CommonDynamicMesh.handLeft;
-                    }
-                    break;
-                default:
-                    controllerDisplayType = InputUtil.ControllerDisplayType.unknown;
-                    commonDynamicMesh = InputUtil.CommonDynamicMesh.Unknown;
-                    break;
-            }
         }
 
         private void SyncWithGazeTick()


### PR DESCRIPTION
# Description

Following changes are made to automatic SteamVR controller tracking:

- Refactored the input tracker component to include `Init()`, `OnEnable()`, and `OnDisable()` methods for clearer lifecycle handling.
- Implemented logic to track SteamVR controller movement without requiring a DynamicObject component.
- Added a fallback mechanism in the controller tracking component to handle unknown controller types automatically.
- Moved `SetControllerFromFallback()` from DynamicObject to InputUtil

Height Task ID(s) (If applicable): T-11859

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
