### PR TITLE
Active Session View sensor allowlist

### DIFF
--- a/Runtime/ActiveSessionView/Editor/ActiveSessionViewEditor.cs
+++ b/Runtime/ActiveSessionView/Editor/ActiveSessionViewEditor.cs
@@ -181,6 +181,27 @@ namespace Cognitive3D.ActiveSession
             sc.LineWidth = EditorGUILayout.Slider("Sensor Line Width", sc.LineWidth, 0.001f, 0.03f);
             sc.MaxSensorTimeSpan = EditorGUILayout.Slider("Sensor Timespan", sc.MaxSensorTimeSpan, 10, 120);
 
+            EditorGUILayout.LabelField("Allowed Sensor Names", EditorStyles.boldLabel);
+
+            for (int i = 0; i < sc.allowedSensorNames.Count; i++)
+            {
+                EditorGUILayout.BeginHorizontal();
+                sc.allowedSensorNames[i] = EditorGUILayout.TextField($"Sensor {i}", sc.allowedSensorNames[i]);
+                
+                if (GUILayout.Button("Remove", GUILayout.Width(60)))
+                {
+                    sc.allowedSensorNames.RemoveAt(i);
+                    i--; // Adjust index after removal
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            // Add button
+            if (GUILayout.Button("Add Sensor"))
+            {
+                sc.allowedSensorNames.Add("");
+            }
+
 
             //internal
             foldout = EditorGUILayout.Foldout(foldout, "Internal");

--- a/Runtime/ActiveSessionView/Scripts/SensorCanvas.cs
+++ b/Runtime/ActiveSessionView/Scripts/SensorCanvas.cs
@@ -37,6 +37,8 @@ namespace Cognitive3D.ActiveSession
         public float LineWidth = 0.03f;
         public float MaxSensorTimeSpan = 120;
 
+        public List<string> allowedSensorNames = new List<string>();
+
         public SensorEntry[] SensorEntries;
         public SensorRenderCamera renderCamera;
 
@@ -75,6 +77,15 @@ namespace Cognitive3D.ActiveSession
 
         private void SensorRecorder_OnNewSensorRecorded(string sensorName, float value)
         {
+            //reject sensors if there is an allow list and the sensor is not included
+            if (allowedSensorNames.Count > 0)
+            {
+                if (allowedSensorNames.Contains(sensorName) == false)
+                {
+                    return;
+                }
+            }
+
             for (int i = 0; i < SensorEntries.Length; i++)
             {
                 if (SensorEntries[i].name == sensorName)


### PR DESCRIPTION
# Description

Added a list for active session view to allow sensors by name. This is to enable custom sensors to be displayed instead of all the internal Cognitive3D sensors

Height Task ID(s) (If applicable):

## Type of change

> Note: delete the lines that are not applicable and check the boxes for the type of change.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My changes will not interrupt or disrupt automated build processes
- [ ] I have checked all outgoing links (i.e. to documentation) for validity
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned this PR to myself in GitHub
- [ ] I have assigned and notified Reviewers for this PR
