### PR TITLE
Support for Eye Tracking in OpenXR Vive

### DIFF
--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -26,7 +26,8 @@
         "meta.xr.mrutilitykit",
         "Unity.Netcode.Runtime",
         "Unity.XR.Hands",
-        "VIVE.OpenXR"
+        "VIVE.OpenXR",
+        "Unity.XR.OpenXR"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -25,7 +25,8 @@
         "PhotonRealtime",
         "meta.xr.mrutilitykit",
         "Unity.Netcode.Runtime",
-        "Unity.XR.Hands"
+        "Unity.XR.Hands",
+        "VIVE.OpenXR"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -84,6 +85,11 @@
             "name": "com.unity.xr.oculus",
             "expression": "",
             "define": "COGNITIVE3D_META_OCULUS_XR"
+        },
+        {
+            "name": "com.htc.upm.vive.openxr",
+            "expression": "",
+            "define": "COGNITIVE3D_VIVE_OPENXR"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Scripts/FixationRecorder.cs
+++ b/Runtime/Scripts/FixationRecorder.cs
@@ -786,7 +786,6 @@ namespace Cognitive3D
                         worldDirection = GameplayReferences.HMD.transform.parent.TransformDirection(worldDirection);
                         Vector3 worldOrigin = GameplayReferences.HMD.transform.parent.TransformPoint(centerPos);
                         ray = new Ray(worldOrigin, worldDirection);
-                        Debug.DrawRay(worldOrigin, worldDirection * 100f, Color.red);
                     }
                     else
                     {

--- a/Runtime/Scripts/FixationRecorder.cs
+++ b/Runtime/Scripts/FixationRecorder.cs
@@ -863,7 +863,7 @@ namespace Cognitive3D
                 }
             }
 #endif
-                UnityEngine.XR.Eyes eyes;
+            UnityEngine.XR.Eyes eyes;
             if (UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.RightEye).TryGetFeatureValue(UnityEngine.XR.CommonUsages.eyesData, out eyes))
             {
                 float open;

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -63,7 +63,7 @@ namespace Cognitive3D
         {
             get
             {
-#if C3D_SRANIPAL || C3D_VARJOVR || C3D_VARJOXR || C3D_PICOVR || C3D_OMNICEPT || COGNITIVE3D_VIVE_OPENXR
+#if C3D_SRANIPAL || C3D_VARJOVR || C3D_VARJOXR || C3D_PICOVR || C3D_OMNICEPT
                 return true;
 #elif C3D_PICOXR
                 return Unity.XR.PXR.PXR_Manager.Instance.eyeTracking;
@@ -89,6 +89,9 @@ namespace Cognitive3D
                 }
 
                 return true;
+#elif COGNITIVE3D_VIVE_OPENXR
+                var feature = UnityEngine.XR.OpenXR.OpenXRSettings.Instance.GetFeature<VIVE.OpenXR.EyeTracker.ViveEyeTracker>();
+                return feature != null && feature.enabled;
 #elif C3D_DEFAULT
                 var head = InputDevices.GetDeviceAtXRNode(XRNode.Head);
                 Eyes eyedata;

--- a/Runtime/Scripts/GameplayReferences.cs
+++ b/Runtime/Scripts/GameplayReferences.cs
@@ -63,7 +63,7 @@ namespace Cognitive3D
         {
             get
             {
-#if C3D_SRANIPAL || C3D_VARJOVR || C3D_VARJOXR || C3D_PICOVR || C3D_OMNICEPT
+#if C3D_SRANIPAL || C3D_VARJOVR || C3D_VARJOXR || C3D_PICOVR || C3D_OMNICEPT || COGNITIVE3D_VIVE_OPENXR
                 return true;
 #elif C3D_PICOXR
                 return Unity.XR.PXR.PXR_Manager.Instance.eyeTracking;

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -210,6 +210,31 @@ namespace Cognitive3D
 #else
         static Vector3 GetLookDirection()
         {
+#if COGNITIVE3D_VIVE_OPENXR
+            VIVE.OpenXR.XR_HTC_eye_tracker.Interop.GetEyeGazeData(out VIVE.OpenXR.EyeTracker.XrSingleEyeGazeDataHTC[] out_gazes);
+
+            if (out_gazes != null && out_gazes.Length >= 2)
+            {
+                var leftGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_LEFT_HTC];
+                var rightGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_RIGHT_HTC];
+
+                if (leftGaze.isValid && FixationRecorder.LeftEyeOpen() &&  rightGaze.isValid && FixationRecorder.RightEyeOpen())
+                {
+                    Quaternion leftRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(leftGaze.gazePose.orientation);
+                    Quaternion rightRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(rightGaze.gazePose.orientation);
+
+                    Quaternion centerRot = Quaternion.Slerp(leftRot, rightRot, 0.5f);
+
+                    Vector3 worldGazeDirection = centerRot * Vector3.forward;
+                    if (GameplayReferences.HMD.transform.parent != null)
+                    {
+                        worldGazeDirection = GameplayReferences.HMD.transform.parent.TransformDirection(centerRot * Vector3.forward);
+                    }
+                    Debug.DrawRay(GameplayReferences.HMD.position, worldGazeDirection * 100f, Color.red);
+                    return worldGazeDirection;
+                }
+            }
+#endif
             UnityEngine.XR.Eyes eyes;
             var centereye = UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.CenterEye);
 

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -211,30 +211,35 @@ namespace Cognitive3D
         static Vector3 GetLookDirection()
         {
 #if COGNITIVE3D_VIVE_OPENXR
-            VIVE.OpenXR.XR_HTC_eye_tracker.Interop.GetEyeGazeData(out VIVE.OpenXR.EyeTracker.XrSingleEyeGazeDataHTC[] out_gazes);
+            var feature = UnityEngine.XR.OpenXR.OpenXRSettings.Instance.GetFeature<VIVE.OpenXR.EyeTracker.ViveEyeTracker>();
 
-            if (out_gazes != null && out_gazes.Length >= 2)
+            if (feature != null && feature.enabled)
             {
-                var leftGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_LEFT_HTC];
-                var rightGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_RIGHT_HTC];
+                VIVE.OpenXR.XR_HTC_eye_tracker.Interop.GetEyeGazeData(out VIVE.OpenXR.EyeTracker.XrSingleEyeGazeDataHTC[] out_gazes);
 
-                if (leftGaze.isValid && FixationRecorder.LeftEyeOpen() &&  rightGaze.isValid && FixationRecorder.RightEyeOpen())
+                if (out_gazes != null && out_gazes.Length >= 2)
                 {
-                    Quaternion leftRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(leftGaze.gazePose.orientation);
-                    Quaternion rightRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(rightGaze.gazePose.orientation);
+                    var leftGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_LEFT_HTC];
+                    var rightGaze = out_gazes[(int)VIVE.OpenXR.EyeTracker.XrEyePositionHTC.XR_EYE_POSITION_RIGHT_HTC];
 
-                    Quaternion centerRot = Quaternion.Slerp(leftRot, rightRot, 0.5f);
-
-                    Vector3 worldGazeDirection = centerRot * Vector3.forward;
-                    if (GameplayReferences.HMD.transform.parent != null)
+                    if (leftGaze.isValid && FixationRecorder.LeftEyeOpen() && rightGaze.isValid && FixationRecorder.RightEyeOpen())
                     {
-                        worldGazeDirection = GameplayReferences.HMD.transform.parent.TransformDirection(centerRot * Vector3.forward);
+                        Quaternion leftRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(leftGaze.gazePose.orientation);
+                        Quaternion rightRot = VIVE.OpenXR.OpenXRHelper.ToUnityQuaternion(rightGaze.gazePose.orientation);
+
+                        Quaternion centerRot = Quaternion.Slerp(leftRot, rightRot, 0.5f);
+
+                        Vector3 worldGazeDirection = centerRot * Vector3.forward;
+                        if (GameplayReferences.HMD.transform.parent != null)
+                        {
+                            worldGazeDirection = GameplayReferences.HMD.transform.parent.TransformDirection(centerRot * Vector3.forward);
+                        }
+                        return worldGazeDirection;
                     }
-                    return worldGazeDirection;
                 }
             }
 #endif
-            UnityEngine.XR.Eyes eyes;
+                UnityEngine.XR.Eyes eyes;
             var centereye = UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.CenterEye);
 
             if (centereye.TryGetFeatureValue(UnityEngine.XR.CommonUsages.eyesData, out eyes))

--- a/Runtime/Scripts/GazeHelper.cs
+++ b/Runtime/Scripts/GazeHelper.cs
@@ -230,7 +230,6 @@ namespace Cognitive3D
                     {
                         worldGazeDirection = GameplayReferences.HMD.transform.parent.TransformDirection(centerRot * Vector3.forward);
                     }
-                    Debug.DrawRay(GameplayReferences.HMD.position, worldGazeDirection * 100f, Color.red);
                     return worldGazeDirection;
                 }
             }


### PR DESCRIPTION
# Description

The following changes are made to support eye tracking using the OpenXR Vive SDK for PC VR apps

- Added support for eye openness detection using the OpenXR Vive API.
- Updated CombinedWorldGazeRay() to construct gaze rays based on eye tracking data provided by the Vive OpenXR SDK.
- Modified assembly definitions to include VIVE.OpenXR, enabling detection of the Vive package in the project.
- Adjusted GetLookDirection() logic for C3D_DEFAULT in the gaze helper script to account for Vive OpenXR eye tracking input.

Height Task ID(s) (If applicable): T-11952

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
