### PR TITLE
Fix for Controller Manual Setup and Dynamic Data Scene Flush Behavior

### DIFF
--- a/Runtime/Components/ControllerInputTracker.cs
+++ b/Runtime/Components/ControllerInputTracker.cs
@@ -35,12 +35,6 @@ namespace Cognitive3D.Components
             ControllerTracking.OnControllerRegistered += Init;
         }
 
-        void DelayEnable(InputDevice device, XRNode node, bool isValid)
-        {
-            GameplayReferences.OnControllerValidityChange -= DelayEnable;
-            OnSessionBegin();
-        }
-
         void Init()
         {
             string leftHandId = "";

--- a/Runtime/Components/ControllerInputTracker.cs
+++ b/Runtime/Components/ControllerInputTracker.cs
@@ -24,6 +24,9 @@ namespace Cognitive3D.Components
         float nextUpdateTime;
         //records analogue inputs at this interval
 
+        DynamicObject LeftHandDynamicObject;
+        DynamicObject RightHandDynamicObject;
+
         DynamicData LeftHand;
         DynamicData RightHand;
 
@@ -32,10 +35,35 @@ namespace Cognitive3D.Components
             ControllerTracking.OnControllerRegistered += Init;
         }
 
+        void DelayEnable(InputDevice device, XRNode node, bool isValid)
+        {
+            GameplayReferences.OnControllerValidityChange -= DelayEnable;
+            OnSessionBegin();
+        }
+
         void Init()
         {
-            LeftHand = DynamicManager.GetInputDynamicData(InputUtil.InputType.Controller, false);
-            RightHand = DynamicManager.GetInputDynamicData(InputUtil.InputType.Controller, true);
+            string leftHandId = "";
+            string leftControllerDisplay = "";
+
+            string rightHandId = "";
+            string rightControllerDisplay = "";
+            if (!Cognitive3D_Manager.autoInitializePlayerSetup)
+            {
+                TryGetControllerData(false, out leftHandId, out leftControllerDisplay);
+                TryGetControllerData(true, out rightHandId, out rightControllerDisplay);
+            }
+            else
+            {
+                LeftHand = DynamicManager.GetInputDynamicData(InputUtil.InputType.Controller, false);
+                RightHand = DynamicManager.GetInputDynamicData(InputUtil.InputType.Controller, true);
+
+                leftHandId = LeftHand.Id;
+                leftControllerDisplay = LeftHand.ControllerType;
+
+                rightHandId = RightHand.Id;
+                rightControllerDisplay = RightHand.ControllerType;
+            }
 
             Cognitive3D_Manager.SetSessionProperty("c3d.device.controllerinputs.enabled", true);
 #if !C3D_STEAMVR2
@@ -43,7 +71,7 @@ namespace Cognitive3D.Components
             RightLastFrameButtonStates = new Dictionary<string, ButtonState>();
 
             //left hand
-            if (!System.String.IsNullOrEmpty(LeftHand.Id) && InputUtil.TryParseControllerDisplayType(LeftHand.ControllerType, out InputUtil.ControllerDisplayType leftDisplay))
+            if (!System.String.IsNullOrEmpty(leftHandId) && InputUtil.TryParseControllerDisplayType(leftControllerDisplay, out InputUtil.ControllerDisplayType leftDisplay))
             {
                 switch (leftDisplay)
                 {
@@ -124,7 +152,7 @@ namespace Cognitive3D.Components
             }
 
             //right hand
-            if (!System.String.IsNullOrEmpty(RightHand.Id) && InputUtil.TryParseControllerDisplayType(RightHand.ControllerType, out InputUtil.ControllerDisplayType rightDisplay))
+            if (!System.String.IsNullOrEmpty(rightHandId) && InputUtil.TryParseControllerDisplayType(rightControllerDisplay, out InputUtil.ControllerDisplayType rightDisplay))
             {
                 switch (rightDisplay)
                 {
@@ -266,6 +294,31 @@ namespace Cognitive3D.Components
             }
 #endif
         }
+        
+        void TryGetControllerData(bool isRight, out string handId, out string controllerDisplay)
+        {
+            handId = "";
+            controllerDisplay = "";
+
+            if (GameplayReferences.GetControllerTransform(isRight, out Transform tempTransform))
+            {
+                var dynamicObject = tempTransform.GetComponent<DynamicObject>();
+
+                if (isRight)
+                    RightHandDynamicObject = dynamicObject;
+                else
+                    LeftHandDynamicObject = dynamicObject;
+
+                if (dynamicObject != null)
+                {
+                    handId = dynamicObject.GetId();
+                    InputUtil.CommonDynamicMesh tempMesh;
+                    InputUtil.ControllerDisplayType tempDisplay;
+                    dynamicObject.GetControllerTypeData(out tempMesh, out tempDisplay);
+                    controllerDisplay = tempDisplay.ToString();
+                }
+            }
+        }
 
 #if C3D_STEAMVR2
 #region  SteamVR
@@ -301,7 +354,10 @@ namespace Cognitive3D.Components
             		copy.Add(CurrentLeftButtonStates[i]);
             	}
                 CurrentLeftButtonStates.Clear();
-            	DynamicManager.RecordControllerEvent(false, copy);
+            	if (Cognitive3D_Manager.autoInitializePlayerSetup)
+                    DynamicManager.RecordControllerEvent(false, copy);
+                else
+                    DynamicManager.RecordControllerEvent(LeftHandDynamicObject.GetId(), copy);
             }
             if (CurrentRightButtonStates.Count > 0)
             {
@@ -311,7 +367,10 @@ namespace Cognitive3D.Components
                     copy.Add(CurrentRightButtonStates[i]);
                 }
                 CurrentRightButtonStates.Clear();
-                DynamicManager.RecordControllerEvent(true, copy);
+                if (Cognitive3D_Manager.autoInitializePlayerSetup)
+                    DynamicManager.RecordControllerEvent(true, copy);
+                else
+                    DynamicManager.RecordControllerEvent(RightHandDynamicObject.GetId(), copy);
             }
         }
 
@@ -675,7 +734,10 @@ namespace Cognitive3D.Components
                 }
                 CurrentRightButtonStates.Clear();
 
-                DynamicManager.RecordControllerEvent(true, copy);
+                if (Cognitive3D_Manager.autoInitializePlayerSetup)
+                    DynamicManager.RecordControllerEvent(true, copy);
+                else
+                    DynamicManager.RecordControllerEvent(RightHandDynamicObject.GetId(), copy);
             }
             if (CurrentLeftButtonStates.Count > 0)
             {
@@ -686,7 +748,10 @@ namespace Cognitive3D.Components
                 }
                 CurrentLeftButtonStates.Clear();
 
-                DynamicManager.RecordControllerEvent(false, copy);
+                if (Cognitive3D_Manager.autoInitializePlayerSetup)
+                    DynamicManager.RecordControllerEvent(false, copy);
+                else
+                    DynamicManager.RecordControllerEvent(LeftHandDynamicObject.GetId(), copy);
             }
         }
 

--- a/Runtime/Components/ControllerTracking.cs
+++ b/Runtime/Components/ControllerTracking.cs
@@ -127,16 +127,39 @@ namespace Cognitive3D.Components
             }
         }
 
+        void DelayEnable(InputDevice device, XRNode node, bool isValid)
+        {
+            GameplayReferences.OnControllerValidityChange -= DelayEnable;
+            RegisterControllers();
+        }
+
         void RegisterControllers()
         {
-            if (!Cognitive3D_Manager.autoInitializePlayerSetup) return;
+            if (!Cognitive3D_Manager.autoInitializePlayerSetup)
+            {
+                InputDevice device;
+                Transform ignore;
+                if (!GameplayReferences.GetControllerInfo(true, out device) || !GameplayReferences.GetControllerTransform(false,out ignore))
+                {
+                    GameplayReferences.OnControllerValidityChange += DelayEnable;
+                }
+                else if (!GameplayReferences.GetControllerInfo(false, out device) || !GameplayReferences.GetControllerTransform(true, out ignore))
+                {
+                    GameplayReferences.OnControllerValidityChange += DelayEnable;
+                }
+                else
+                {
+                    OnControllerRegistered?.Invoke();
+                }
+                return;
+            }
 
             // Check if the left controller is valid and not yet registered
-            if (!leftControllerRegistered && InputUtil.TryGetInputDevice(XRNode.LeftHand, out InputDevice leftController))
-            {
-                DynamicManager.RegisterController(XRNode.LeftHand, false, FallbackControllerType);
-                leftControllerRegistered = true;
-            }
+                if (!leftControllerRegistered && InputUtil.TryGetInputDevice(XRNode.LeftHand, out InputDevice leftController))
+                {
+                    DynamicManager.RegisterController(XRNode.LeftHand, false, FallbackControllerType);
+                    leftControllerRegistered = true;
+                }
 
             // Check if the right controller is valid and not yet registered
             if (!rightControllerRegistered && InputUtil.TryGetInputDevice(XRNode.RightHand, out InputDevice rightController))

--- a/Runtime/Internal/DynamicManager.cs
+++ b/Runtime/Internal/DynamicManager.cs
@@ -35,6 +35,18 @@ namespace Cognitive3D
         }
 
         /// <summary>
+        /// Immediately processes all active dynamic objects in the array,
+        /// bypassing the normal update loop. This is used during
+        /// scene unloads or special cases where dynamic object state needs
+        /// to be flushed before the next frame.
+        /// </summary>
+        internal static void ForceProcessDynamicObjects()
+        {
+            int numTicks = 0;
+            ProcessDynamicArray(ref ActiveDynamicObjectsArray, 0, ref numTicks);
+        }
+
+        /// <summary>
         /// Resets content of Dynamic Manager to avoid carrying internally stored data between game states when no session is active
         /// Intended only for in-app editor tooling
         /// </summary>
@@ -413,7 +425,7 @@ namespace Cognitive3D
 
         internal static void RegisterController(DynamicData data)
         {
-            //check for duplicate ids in all data
+            // check for duplicate ids in all data
             for (int i = 0; i < ActiveDynamicObjectsArray.Length; i++)
             {
                 if (ActiveDynamicObjectsArray[i].active && data.Id == ActiveDynamicObjectsArray[i].Id)

--- a/Runtime/Internal/Serialization/CoreInterface.cs
+++ b/Runtime/Internal/Serialization/CoreInterface.cs
@@ -253,9 +253,9 @@ namespace Cognitive3D
         }
         #endregion
 
-        internal static void FlushSceneChange(bool copyToCache)
+        internal static void FlushSceneChange(bool copyToCache, bool flushDynamics)
         {
-            SharedCore.FlushSceneChange(copyToCache);
+            SharedCore.FlushSceneChange(copyToCache, flushDynamics);
         }
 
         internal static void Flush(bool copyToCache)

--- a/Runtime/Internal/Serialization/SharedCore.cs
+++ b/Runtime/Internal/Serialization/SharedCore.cs
@@ -20,7 +20,7 @@ namespace Cognitive3D.Serialization
         #endregion
 
 
-        internal static void FlushSceneChange(bool copyToCache)
+        internal static void FlushSceneChange(bool copyToCache, bool flushDynamics)
         {
             if (!IsInitialized) { return; }
 
@@ -29,7 +29,7 @@ namespace Cognitive3D.Serialization
             SerializeSensors(copyToCache);
             SerializeFixations(copyToCache);
             SerializeBoundaryShapes(copyToCache);
-            SerializeDynamicImmediate(copyToCache);
+            if (flushDynamics) SerializeDynamicImmediate(copyToCache);
         }
 
         internal static void Flush(bool copyToCache)

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -436,7 +436,7 @@ namespace Cognitive3D
             //DO NOT FLUSH DYNAMICS because dynamics from the next scene are already loaded
             if (!string.IsNullOrEmpty(TrackingSceneId))
             {
-                CoreInterface.FlushSceneChange(true);
+                CoreInterface.FlushSceneChange(true, false);
             }
 
             // upload session properties to new scene
@@ -468,7 +468,8 @@ namespace Cognitive3D
             // Flush recorded data when scene unloads
             if (TrackingScene != null)
             {
-                CoreInterface.FlushSceneChange(true);
+                DynamicManager.ForceProcessDynamicObjects();
+                CoreInterface.FlushSceneChange(true, true);
             }
 
             // upload session properties to new scene

--- a/Runtime/Scripts/DynamicObject.cs
+++ b/Runtime/Scripts/DynamicObject.cs
@@ -112,6 +112,8 @@ namespace Cognitive3D
             StartingScale = transform.lossyScale;
             string registerMeshName = MeshName;
 
+            IsController = inputType == InputUtil.InputType.Controller || inputType == InputUtil.InputType.Hand;
+
             // if a controller, delay registering the controller until the controller name has returned something valid
             // if current device is hands or null, then use fallback
             if (IsController)
@@ -122,8 +124,8 @@ namespace Cognitive3D
                 //  and InputDevice.name gives us nothing
                 if (Cognitive3D_Manager.Instance?.GetComponent<Cognitive3D.Components.HandTracking>())
                 {
-                    // If starting with hands or none; use fallback controller
-                    if (InputUtil.GetCurrentTrackedDevice() == InputUtil.InputType.Hand || InputUtil.GetCurrentTrackedDevice() == InputUtil.InputType.None)
+                    // If starting with hands; use fallback controller which is hand
+                    if (InputUtil.GetCurrentTrackedDevice() == InputUtil.InputType.Hand)
                     {
                         // just quickly look up controller by type, isRight
                         InputUtil.SetControllerFromFallback(FallbackControllerType, IsRight, out controllerDisplayType, out commonDynamicMesh);
@@ -188,7 +190,7 @@ namespace Cognitive3D
 
             DataId = Data.Id;
 
-            if (inputType == InputUtil.InputType.Controller || inputType == InputUtil.InputType.Hand)
+            if (IsController)
             {
                 Cognitive3D.DynamicManager.RegisterController(Data);
             }


### PR DESCRIPTION
# Description

The following changes address the controller registration issue in manual setup and the dynamic data flushing behavior during scene transitions:

- Updated `SceneChangeFlush()` to flush dynamic object data only during scene unload, preventing unintended loss of dynamic manifests
- Added a call to force process dynamic objects on scene unload, ensuring dynamic removal events are captured and sent with the correct (unloading) scene.
- Fixed controller identification for manual setup by setting `IsController` at runtime based on the detected input type (controller or hand), since `IsController` is no longer set manually in the inspector.
- Removed the logic that allowed registration for controllers with None input type, which previously caused the controller to be registered based on the fallback
- Implemented logic to trigger the `ControllerRegister` event inside `ControllerTracking` when `autoInitializePlayerSetup` is false (manual setup). This ensures that Init() is properly called on `ControllerInputTracking`, enabling button press tracking in manual setups.

Linear ID(s) (If applicable): SDK-20 & SDK-11

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
