### PR TITLE
Fix Boundary Recording Issue Across Scenes

### DIFF
--- a/Editor/SegmentAnalytics.cs
+++ b/Editor/SegmentAnalytics.cs
@@ -170,10 +170,11 @@ namespace Cognitive3D
                 var bytes = Encoding.UTF8.GetBytes(data);
 
                 using (var request = new UnityWebRequest(trackURL, UnityWebRequest.kHttpVerbPOST))
+                using (var uploadHandler = new UploadHandlerRaw(bytes))
                 {
                     request.disposeUploadHandlerOnDispose = true;
                     request.disposeDownloadHandlerOnDispose = true;
-                    request.uploadHandler = new UploadHandlerRaw(bytes);
+                    request.uploadHandler = uploadHandler;
                     request.downloadHandler = new DownloadHandlerBuffer();
 
                     request.SetRequestHeader("Content-Type", "application/json");

--- a/Runtime/Components/Boundary.cs
+++ b/Runtime/Components/Boundary.cs
@@ -11,6 +11,11 @@ namespace Cognitive3D.Components
     {
 #if ((C3D_OCULUS || C3D_DEFAULT || C3D_VIVEWAVE || C3D_PICOXR) && !UNITY_EDITOR) || C3D_STEAMVR2
         /// <summary>
+        /// Track whether the boundary has been initialized in this session
+        /// </summary>
+        private static bool boundaryInitializedThisSession = false;
+
+        /// <summary>
         /// The previous list of coordinates (local to tracking space) describing the boundary <br/>
         /// Used for comparison to determine if the boundary changed
         /// </summary>
@@ -52,30 +57,46 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
+            boundaryInitializedThisSession = false; // Reset for new session
             StartCoroutine(InitializeBoundaryRecordWithDelay());
+        }
+
+        void OnLevelLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode, bool didChangeSceneId)
+        {
+            if (didChangeSceneId && Cognitive3D_Manager.TrackingScene != null)
+            {
+                StartCoroutine(InitializeBoundaryRecordWithDelay());
+            }
         }
 
         private IEnumerator InitializeBoundaryRecordWithDelay()
         {
             yield return new WaitForSeconds(INITIALIZATION_DELAY_SECONDS);
 
-            // The rest of your original OnSessionBegin code
-            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
-
-            // Get initial values of boundary and tracking space
+            // Always record boundary shape and tracking space on scene load (including first scene)
             currentBoundaryPoints = BoundaryUtil.GetCurrentBoundaryPoints();
-            previousBoundaryPoints = currentBoundaryPoints; // since there is no "previous"
+            previousBoundaryPoints = currentBoundaryPoints;
 
-            // Initialize the string builder to an appropriate size based on boundary points
+            // Only initialize once per session (on first scene)
+            if (!boundaryInitializedThisSession)
+            {
+                // Always initialize the string builder, even if there are no boundary points
+                int numPoints = (currentBoundaryPoints != null) ? currentBoundaryPoints.Length : 4; // Default to 4 if no boundary
+                CoreInterface.InitializeBoundary(numPoints + (int)Mathf.Ceil(NUM_BOUNDARY_POINTS_GRACE_FOR_STRINGBUILDER * numPoints));
+
+                boundaryInitializedThisSession = true;
+
+                Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+                Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
+                Cognitive3D_Manager.OnLevelLoaded += OnLevelLoaded;
+            }
+
             if (currentBoundaryPoints != null)
             {
-                CoreInterface.InitializeBoundary(currentBoundaryPoints.Length + (int)Mathf.Ceil(NUM_BOUNDARY_POINTS_GRACE_FOR_STRINGBUILDER * currentBoundaryPoints.Length));
-                // Record initial boundary shape
                 CoreInterface.RecordBoundaryShape(currentBoundaryPoints, Util.Timestamp(Time.frameCount));
             }
 
-            // Record initial tracking space position and rotation
+            // Record tracking space position and rotation
             if (BoundaryUtil.TryGetTrackingSpaceTransform(out var customTransform))
             {
                 CoreInterface.RecordTrackingSpaceTransform(customTransform, Util.Timestamp(Time.frameCount));
@@ -133,8 +154,10 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnPreSessionEnd()
         {
+            Cognitive3D_Manager.OnLevelLoaded -= OnLevelLoaded;
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnTick -= Cognitive3D_Manager_OnTick;
+            boundaryInitializedThisSession = false; // Reset for next session
         }
 #endif
 

--- a/Runtime/Internal/Serialization/SharedCore.cs
+++ b/Runtime/Internal/Serialization/SharedCore.cs
@@ -1783,6 +1783,7 @@ namespace Cognitive3D.Serialization
 
             // Clear and prepare for next batch
             trackingSpaces.Clear();
+            boundaryShapes.Clear();
             boundarybuilder.Clear();
             boundarybuilder.Append("{\"data\":[");
         }


### PR DESCRIPTION
# Description

This PR addresses issues with boundary recording in different scenes and a small memory leak in Unity 2021. The following changes were made:
- Force recording of boundary shape and tracking space data on level load, even if the values haven’t changed
- Initialize the boundary string builder once at session start, regardless of whether boundary points are available after the 1-second delay
- Fix a minor memory leak in Unity 2021 caused by Segment open web requests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
- [x] I have asked GitHub Copilot to review this PR
