### PR TITLE
Release 2.1.5

### DIFF
--- a/Editor/Cognitive3DEditor.asmdef
+++ b/Editor/Cognitive3DEditor.asmdef
@@ -25,7 +25,8 @@
         "Unity.XR.PicoXR",
         "meta.xr.mrutilitykit",
         "Unity.Netcode.Runtime",
-        "Normal.Realtime.Shared"
+        "Normal.Realtime.Shared",
+        "VIVE.OpenXR"
     ],
     "includePlatforms": [
         "Editor"
@@ -91,6 +92,11 @@
             "name": "com.meta.xr.sdk.platform",
             "expression": "",
             "define": "COGNITIVE3D_META_PLATFORM"
+        },
+        {
+            "name": "com.htc.upm.vive.openxr",
+            "expression": "2.5.0",
+            "define": "COGNITIVE3D_VIVE_OPENXR_2_5_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -241,11 +241,11 @@ namespace Cognitive3D
                 if (GUILayout.Button("Upload Mesh", "ButtonRight", GUILayout.Height(30)))
                 {
                     List<GameObject> uploadList = new List<GameObject>(Selection.gameObjects);
-                    bool uploadConfirmed = ExportUtility.UploadSelectedDynamicObjectMeshes(uploadList, true);
-                    if (uploadConfirmed)
+                    System.Action uploadMeshesOnManifest = delegate
                     {
-                        UploadCustomIdForAggregation();
-                    }
+                        ExportUtility.UploadSelectedDynamicObjectMeshes(uploadList, true);
+                    };
+                    UploadCustomIdForAggregation(uploadMeshesOnManifest);
                 }
                 EditorGUI.EndDisabledGroup();
 
@@ -318,7 +318,7 @@ namespace Cognitive3D
             serializedObject.ApplyModifiedProperties();
         }
 
-        void UploadCustomIdForAggregation()
+        void UploadCustomIdForAggregation(System.Action uploadMeshesOnManifest)
         {
             var dyn = target as DynamicObject;
             if (dyn.idSource == DynamicObject.IdSourceType.CustomID)
@@ -331,7 +331,7 @@ namespace Cognitive3D
                         new float[3] { dyn.transform.lossyScale.x, dyn.transform.lossyScale.y, dyn.transform.lossyScale.z },
                         new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
                         new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));
-                    EditorCore.UploadManifest(manifest, null);
+                    EditorCore.UploadManifest(manifest, uploadMeshesOnManifest);
                 });
             }
             else if (dyn.IdPool != null)
@@ -347,7 +347,7 @@ namespace Cognitive3D
                             new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
                             new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));
                     }
-                    EditorCore.UploadManifest(manifest, null);
+                    EditorCore.UploadManifest(manifest, uploadMeshesOnManifest);
                 });
             }
         }

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -318,38 +318,62 @@ namespace Cognitive3D
             serializedObject.ApplyModifiedProperties();
         }
 
-        void UploadCustomIdForAggregation(System.Action uploadMeshesOnManifest)
+        void UploadCustomIdForAggregation(System.Action callback)
         {
             var dyn = target as DynamicObject;
+
+            if (dyn.idSource == DynamicObject.IdSourceType.GeneratedID)
+            {
+                callback?.Invoke();
+                return;
+            }
+
             if (dyn.idSource == DynamicObject.IdSourceType.CustomID)
             {
                 Debug.Log("Cognitive3D Dynamic Object: upload custom id to scene");
-                EditorCore.RefreshSceneVersion(delegate ()
-                {
-                    AggregationManifest manifest = new AggregationManifest();
-                    manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.CustomId, dyn.IsController,
-                        new float[3] { dyn.transform.lossyScale.x, dyn.transform.lossyScale.y, dyn.transform.lossyScale.z },
-                        new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
-                        new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));
-                    EditorCore.UploadManifest(manifest, uploadMeshesOnManifest);
-                });
+                UploadManifestWithIds(dyn, new[] { dyn.CustomId }, callback);
             }
             else if (dyn.IdPool != null)
             {
                 Debug.Log("Cognitive3D Dynamic Object: Upload id pool to scene");
-                EditorCore.RefreshSceneVersion(delegate ()
-                {
-                    AggregationManifest manifest = new AggregationManifest();
-                    for (int i = 0; i < dyn.IdPool.Ids.Length; i++)
-                    {
-                        manifest.objects.Add(new AggregationManifest.AggregationManifestEntry(dyn.gameObject.name, dyn.MeshName, dyn.IdPool.Ids[i], dyn.IsController,
-                            new float[3] { dyn.transform.lossyScale.x, dyn.transform.lossyScale.y, dyn.transform.lossyScale.z },
-                            new float[3] { dyn.transform.position.x, dyn.transform.position.y, dyn.transform.position.z },
-                            new float[4] { dyn.transform.rotation.x, dyn.transform.rotation.y, dyn.transform.rotation.z, dyn.transform.rotation.w }));
-                    }
-                    EditorCore.UploadManifest(manifest, uploadMeshesOnManifest);
-                });
+                UploadManifestWithIds(dyn, dyn.IdPool.Ids, callback);
             }
+            else
+            {
+                callback?.Invoke();
+            }
+        }
+
+        void UploadManifestWithIds(DynamicObject dyn, string[] ids, System.Action callback)
+        {
+            EditorCore.RefreshSceneVersion(() =>
+            {
+                var manifest = new AggregationManifest();
+                foreach (var id in ids)
+                {
+                    var entry = CreateManifestEntry(dyn, id);
+                    manifest.objects.Add(entry);
+                }
+                EditorCore.UploadManifest(manifest, callback);
+            });
+        }
+
+        AggregationManifest.AggregationManifestEntry CreateManifestEntry(DynamicObject dyn, string id)
+        {
+            var transform = dyn.transform;
+            var scale = new float[3] { transform.lossyScale.x, transform.lossyScale.y, transform.lossyScale.z };
+            var position = new float[3] { transform.position.x, transform.position.y, transform.position.z };
+            var rotation = new float[4] { transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w };
+
+            return new AggregationManifest.AggregationManifestEntry(
+                dyn.gameObject.name,
+                dyn.MeshName,
+                id,
+                dyn.IsController,
+                scale,
+                position,
+                rotation
+            );
         }
 
         void CheckCustomId()

--- a/Editor/DynamicObjectInspector.cs
+++ b/Editor/DynamicObjectInspector.cs
@@ -361,9 +361,9 @@ namespace Cognitive3D
         AggregationManifest.AggregationManifestEntry CreateManifestEntry(DynamicObject dyn, string id)
         {
             var transform = dyn.transform;
-            var scale = new float[3] { transform.lossyScale.x, transform.lossyScale.y, transform.lossyScale.z };
-            var position = new float[3] { transform.position.x, transform.position.y, transform.position.z };
-            var rotation = new float[4] { transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w };
+            var scale = new float[] { transform.lossyScale.x, transform.lossyScale.y, transform.lossyScale.z };
+            var position = new float[] { transform.position.x, transform.position.y, transform.position.z };
+            var rotation = new float[] { transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w };
 
             return new AggregationManifest.AggregationManifestEntry(
                 dyn.gameObject.name,

--- a/Editor/ExportUtility.cs
+++ b/Editor/ExportUtility.cs
@@ -2368,6 +2368,7 @@ namespace Cognitive3D
             {
                 DynamicUploadTotal = dynamicObjectForms.Count;
                 DynamicUploadSuccess = 0;
+                DynamicUploadCancelled = false;
                 EditorApplication.update += UpdateUploadDynamics;
             }
             return true;
@@ -2394,6 +2395,7 @@ namespace Cognitive3D
 
         static int DynamicUploadTotal;
         static int DynamicUploadSuccess;
+        static bool DynamicUploadCancelled;
 
         static UnityWebRequest dynamicUploadWWW;
         /// <summary>
@@ -2423,13 +2425,17 @@ namespace Cognitive3D
                 }
             }
 
-            if (EditorUtility.DisplayCancelableProgressBar("Upload Dynamic Object", currentDynamicUploadName, dynamicUploadWWW.uploadProgress))
+            DynamicUploadCancelled =
+                EditorUtility.DisplayCancelableProgressBar("Upload Dynamic Object",
+                    currentDynamicUploadName, dynamicUploadWWW.uploadProgress);
+            
+            if (DynamicUploadCancelled)
             {
+                DynamicUploadCancelled = true;
                 Debug.Log("Cancelled upload of dynamic object: " + currentDynamicUploadName);
                 dynamicUploadWWW.Abort();
                 EditorUtility.ClearProgressBar();
             }
-      
 
             if (!dynamicUploadWWW.isDone) { return; }
             if (!string.IsNullOrEmpty(dynamicUploadWWW.error))

--- a/Editor/ExportUtility.cs
+++ b/Editor/ExportUtility.cs
@@ -2425,9 +2425,9 @@ namespace Cognitive3D
                 }
             }
 
-            DynamicUploadCancelled =
-                EditorUtility.DisplayCancelableProgressBar("Upload Dynamic Object",
-                    currentDynamicUploadName, dynamicUploadWWW.uploadProgress);
+            if (EditorUtility.DisplayCancelableProgressBar("Upload Dynamic Object",
+                    currentDynamicUploadName, dynamicUploadWWW.uploadProgress)) 
+                DynamicUploadCancelled = true;
             
             if (DynamicUploadCancelled)
             {

--- a/Editor/ExportUtility.cs
+++ b/Editor/ExportUtility.cs
@@ -2431,7 +2431,6 @@ namespace Cognitive3D
             
             if (DynamicUploadCancelled)
             {
-                DynamicUploadCancelled = true;
                 Debug.Log("Cancelled upload of dynamic object: " + currentDynamicUploadName);
                 dynamicUploadWWW.Abort();
                 EditorUtility.ClearProgressBar();

--- a/Editor/ExportUtility.cs
+++ b/Editor/ExportUtility.cs
@@ -2433,7 +2433,12 @@ namespace Cognitive3D
             {
                 Debug.Log("Cancelled upload of dynamic object: " + currentDynamicUploadName);
                 dynamicUploadWWW.Abort();
+                dynamicUploadWWW.Dispose();
+                dynamicUploadWWW = null;      // Reset to null
+                dynamicObjectForms.Clear();   // Clear remaining queued uploads
+                EditorApplication.update -= UpdateUploadDynamics;
                 EditorUtility.ClearProgressBar();
+                return;
             }
 
             if (!dynamicUploadWWW.isDone) { return; }

--- a/Editor/Legacy/LegacySceneSetupWindow.cs
+++ b/Editor/Legacy/LegacySceneSetupWindow.cs
@@ -1668,7 +1668,7 @@ namespace Cognitive3D
                     if (!isSetupComplete)
                     {
                         // Automatically append input bindings for SteamVR
-                        appearDisabled = !Cognitive3D_Manager.Instance.autoInitializePlayerSetup;
+                        appearDisabled = Cognitive3D_Manager.Instance == null || !Cognitive3D_Manager.Instance.autoInitializePlayerSetup;
                         needsConfirmation = appearDisabled;
                         onclick += () => AppendSteamVRBindings();
                     }

--- a/Editor/Legacy/LegacySceneSetupWindow.cs
+++ b/Editor/Legacy/LegacySceneSetupWindow.cs
@@ -1668,7 +1668,7 @@ namespace Cognitive3D
                     if (!isSetupComplete)
                     {
                         // Automatically append input bindings for SteamVR
-                        appearDisabled = !Cognitive3D_Manager.autoInitializePlayerSetup;
+                        appearDisabled = !Cognitive3D_Manager.Instance.autoInitializePlayerSetup;
                         needsConfirmation = appearDisabled;
                         onclick += () => AppendSteamVRBindings();
                     }

--- a/Editor/ProjectValidation/Items/ProjectValidationItems.cs
+++ b/Editor/ProjectValidation/Items/ProjectValidationItems.cs
@@ -666,6 +666,37 @@ namespace Cognitive3D
             );
 #elif C3D_DEFAULT
 
+#if COGNITIVE3D_VIVE_OPENXR_2_5_OR_NEWER
+            var viveFeature = OpenXRSettings.GetSettingsForBuildTargetGroup(BuildTargetGroup.Android).
+                                GetFeature<VIVE.OpenXR.VIVEFocus3Feature>();
+
+            if (viveFeature != null && viveFeature.enabled)
+            {
+                // Check hand tracking
+                var handTrackingFeature = OpenXRSettings.GetSettingsForBuildTargetGroup(BuildTargetGroup.Android)
+                                            .GetFeature<VIVE.OpenXR.Hand.ViveHandTracking>();
+                
+                if (handTrackingFeature != null)
+                {
+                    ProjectValidation.AddItem(
+                        level: ProjectValidation.ItemLevel.Required,
+                        category: CATEGORY,
+                        actionType: ProjectValidation.ItemAction.Fix,
+                        message: "VIVE Hand Tracking is not enabled in OpenXR settings. Hand tracking data will not be recorded. Enable VIVE Hand Tracking Support?",
+                        fixmessage: "VIVE Hand Tracking Support is enabled in OpenXR settings.",
+                        checkAction: () =>
+                        {
+                            return handTrackingFeature.enabled;
+                        },
+                        fixAction: () =>
+                        {
+                            handTrackingFeature.enabled = true;
+                        }
+                    );
+                }
+            }
+#endif
+
 #if COGNITIVE3D_INCLUDE_COREUTILITIES
             ProjectValidation.FindComponentInActiveScene<XROrigin>(out var xrorigins);
 

--- a/Editor/SegmentAnalytics.cs
+++ b/Editor/SegmentAnalytics.cs
@@ -170,10 +170,11 @@ namespace Cognitive3D
                 var bytes = Encoding.UTF8.GetBytes(data);
 
                 using (var request = new UnityWebRequest(trackURL, UnityWebRequest.kHttpVerbPOST))
+                using (var uploadHandler = new UploadHandlerRaw(bytes))
                 {
                     request.disposeUploadHandlerOnDispose = true;
                     request.disposeDownloadHandlerOnDispose = true;
-                    request.uploadHandler = new UploadHandlerRaw(bytes);
+                    request.uploadHandler = uploadHandler;
                     request.downloadHandler = new DownloadHandlerBuffer();
 
                     request.SetRequestHeader("Content-Type", "application/json");

--- a/Runtime/Components/Boundary.cs
+++ b/Runtime/Components/Boundary.cs
@@ -71,6 +71,15 @@ namespace Cognitive3D.Components
 
         private IEnumerator InitializeBoundaryRecordWithDelay()
         {
+            // Prevent race condition: claim initialization immediately before delay
+            // If multiple coroutines start (e.g., from rapid session start + level load),
+            // only the first one should register event handlers
+            bool shouldInitialize = !boundaryInitializedThisSession;
+            if (shouldInitialize)
+            {
+                boundaryInitializedThisSession = true;
+            }
+
             yield return new WaitForSeconds(INITIALIZATION_DELAY_SECONDS);
 
             // Always record boundary shape and tracking space on scene load (including first scene)
@@ -78,13 +87,11 @@ namespace Cognitive3D.Components
             previousBoundaryPoints = currentBoundaryPoints;
 
             // Only initialize once per session (on first scene)
-            if (!boundaryInitializedThisSession)
+            if (shouldInitialize)
             {
                 // Always initialize the string builder, even if there are no boundary points
                 int numPoints = (currentBoundaryPoints != null) ? currentBoundaryPoints.Length : 4; // Default to 4 if no boundary
                 CoreInterface.InitializeBoundary(numPoints + (int)Mathf.Ceil(NUM_BOUNDARY_POINTS_GRACE_FOR_STRINGBUILDER * numPoints));
-
-                boundaryInitializedThisSession = true;
 
                 Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
                 Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;

--- a/Runtime/Components/Boundary.cs
+++ b/Runtime/Components/Boundary.cs
@@ -11,6 +11,11 @@ namespace Cognitive3D.Components
     {
 #if ((C3D_OCULUS || C3D_DEFAULT || C3D_VIVEWAVE || C3D_PICOXR) && !UNITY_EDITOR) || C3D_STEAMVR2
         /// <summary>
+        /// Track whether the boundary has been initialized in this session
+        /// </summary>
+        private static bool boundaryInitializedThisSession = false;
+
+        /// <summary>
         /// The previous list of coordinates (local to tracking space) describing the boundary <br/>
         /// Used for comparison to determine if the boundary changed
         /// </summary>
@@ -52,30 +57,46 @@ namespace Cognitive3D.Components
         protected override void OnSessionBegin()
         {
             base.OnSessionBegin();
+            boundaryInitializedThisSession = false; // Reset for new session
             StartCoroutine(InitializeBoundaryRecordWithDelay());
+        }
+
+        void OnLevelLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode, bool didChangeSceneId)
+        {
+            if (didChangeSceneId && Cognitive3D_Manager.TrackingScene != null)
+            {
+                StartCoroutine(InitializeBoundaryRecordWithDelay());
+            }
         }
 
         private IEnumerator InitializeBoundaryRecordWithDelay()
         {
             yield return new WaitForSeconds(INITIALIZATION_DELAY_SECONDS);
 
-            // The rest of your original OnSessionBegin code
-            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
-            Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
-
-            // Get initial values of boundary and tracking space
+            // Always record boundary shape and tracking space on scene load (including first scene)
             currentBoundaryPoints = BoundaryUtil.GetCurrentBoundaryPoints();
-            previousBoundaryPoints = currentBoundaryPoints; // since there is no "previous"
+            previousBoundaryPoints = currentBoundaryPoints;
 
-            // Initialize the string builder to an appropriate size based on boundary points
+            // Only initialize once per session (on first scene)
+            if (!boundaryInitializedThisSession)
+            {
+                // Always initialize the string builder, even if there are no boundary points
+                int numPoints = (currentBoundaryPoints != null) ? currentBoundaryPoints.Length : 4; // Default to 4 if no boundary
+                CoreInterface.InitializeBoundary(numPoints + (int)Mathf.Ceil(NUM_BOUNDARY_POINTS_GRACE_FOR_STRINGBUILDER * numPoints));
+
+                boundaryInitializedThisSession = true;
+
+                Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+                Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
+                Cognitive3D_Manager.OnLevelLoaded += OnLevelLoaded;
+            }
+
             if (currentBoundaryPoints != null)
             {
-                CoreInterface.InitializeBoundary(currentBoundaryPoints.Length + (int)Mathf.Ceil(NUM_BOUNDARY_POINTS_GRACE_FOR_STRINGBUILDER * currentBoundaryPoints.Length));
-                // Record initial boundary shape
                 CoreInterface.RecordBoundaryShape(currentBoundaryPoints, Util.Timestamp(Time.frameCount));
             }
 
-            // Record initial tracking space position and rotation
+            // Record tracking space position and rotation
             if (BoundaryUtil.TryGetTrackingSpaceTransform(out var customTransform))
             {
                 CoreInterface.RecordTrackingSpaceTransform(customTransform, Util.Timestamp(Time.frameCount));
@@ -133,8 +154,10 @@ namespace Cognitive3D.Components
 
         private void Cognitive3D_Manager_OnPreSessionEnd()
         {
+            Cognitive3D_Manager.OnLevelLoaded -= OnLevelLoaded;
             Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
             Cognitive3D_Manager.OnTick -= Cognitive3D_Manager_OnTick;
+            boundaryInitializedThisSession = false; // Reset for next session
         }
 #endif
 

--- a/Runtime/Components/ControllerInputTracker.cs
+++ b/Runtime/Components/ControllerInputTracker.cs
@@ -348,7 +348,7 @@ namespace Cognitive3D.Components
             		copy.Add(CurrentLeftButtonStates[i]);
             	}
                 CurrentLeftButtonStates.Clear();
-            	if (Cognitive3D_Manager.autoInitializePlayerSetup)
+            	if (Cognitive3D_Manager.Instance.autoInitializePlayerSetup)
                     DynamicManager.RecordControllerEvent(false, copy);
                 else
                     DynamicManager.RecordControllerEvent(LeftHandDynamicObject.GetId(), copy);
@@ -361,7 +361,7 @@ namespace Cognitive3D.Components
                     copy.Add(CurrentRightButtonStates[i]);
                 }
                 CurrentRightButtonStates.Clear();
-                if (Cognitive3D_Manager.autoInitializePlayerSetup)
+                if (Cognitive3D_Manager.Instance.autoInitializePlayerSetup)
                     DynamicManager.RecordControllerEvent(true, copy);
                 else
                     DynamicManager.RecordControllerEvent(RightHandDynamicObject.GetId(), copy);

--- a/Runtime/Internal/DynamicManager.cs
+++ b/Runtime/Internal/DynamicManager.cs
@@ -518,7 +518,7 @@ namespace Cognitive3D
                 }
             }
             
-            Util.logError($"No DynamicData found for type {type.ToString()} and isRight " + isRight.ToString());
+            Util.logError($"No DynamicData found for type {type.ToString()} and isRight {isRight.ToString()}");
             return new DynamicData(); // Return null if no matching dynamic data is found
         }
 

--- a/Runtime/Internal/DynamicManager.cs
+++ b/Runtime/Internal/DynamicManager.cs
@@ -518,7 +518,7 @@ namespace Cognitive3D
                 }
             }
             
-            Util.logError($"No DynamicData found for type {type} and isRight {isRight}");
+            Util.logError($"No DynamicData found for type {type.ToString()} and isRight " + isRight.ToString());
             return new DynamicData(); // Return null if no matching dynamic data is found
         }
 

--- a/Runtime/Internal/DynamicManager.cs
+++ b/Runtime/Internal/DynamicManager.cs
@@ -519,7 +519,7 @@ namespace Cognitive3D
             }
             
             Util.logError($"No DynamicData found for type {type.ToString()} and isRight {isRight.ToString()}");
-            return new DynamicData(); // Return null if no matching dynamic data is found
+            return new DynamicData(); // Return empty DynamicData if no matching dynamic data is found
         }
 
         internal static void UpdateDynamicInputEnabledState(InputUtil.InputType currentTrackedDevice)

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -537,7 +537,7 @@ namespace Cognitive3D
             InputDevices.GetDevices(devices);
             foreach (var device in devices)
             {
-                if (device.characteristics.HasFlag(InputDeviceCharacteristics.Controller))
+                if ((device.characteristics & InputDeviceCharacteristics.Controller) != 0)
                 {
                     return InputType.Controller;
                 }

--- a/Runtime/Internal/Serialization/JsonUtil.cs
+++ b/Runtime/Internal/Serialization/JsonUtil.cs
@@ -145,13 +145,13 @@ namespace Cognitive3D.Serialization
 
             if (centimeterLimit)
             {
-                builder.Append(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.00}", pos[0]));
+                builder.Append(pos[0].ToString("0.00", System.Globalization.CultureInfo.InvariantCulture));
 
                 builder.Append(",");
-                builder.Append(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.00}", pos[1]));
+                builder.Append(pos[1].ToString("0.00", System.Globalization.CultureInfo.InvariantCulture));
 
                 builder.Append(",");
-                builder.Append(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0:0.00}", pos[2]));
+                builder.Append(pos[2].ToString("0.00", System.Globalization.CultureInfo.InvariantCulture));
 
             }
             else

--- a/Runtime/Internal/Serialization/SharedCore.cs
+++ b/Runtime/Internal/Serialization/SharedCore.cs
@@ -1783,6 +1783,7 @@ namespace Cognitive3D.Serialization
 
             // Clear and prepare for next batch
             trackingSpaces.Clear();
+            boundaryShapes.Clear();
             boundarybuilder.Clear();
             boundarybuilder.Append("{\"data\":[");
         }

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -226,6 +226,12 @@ namespace Cognitive3D
                 Util.logWarning("The scene has not been uploaded to the dashboard. The user activity will not be captured.");
             }
 
+            // Record the start time for the initial scene
+            if (!string.IsNullOrEmpty(scene.path) && !SceneStartTimeDict.ContainsKey(scene.path))
+            {
+                SceneStartTimeDict.Add(scene.path, Time.time);
+            }
+
             // TODO: support for additive scenes? According to doc, it'll be somehow considered single mode
             InvokeLevelLoadedEvent(scene, UnityEngine.SceneManagement.LoadSceneMode.Single, true);
 

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -29,7 +29,7 @@ namespace Cognitive3D
     [DefaultExecutionOrder(-50)]
     public class Cognitive3D_Manager : MonoBehaviour
     {
-        public static readonly string SDK_VERSION = "2.1.0";
+        public static readonly string SDK_VERSION = "2.1.5";
     
         private static Cognitive3D_Manager instance;
         public static Cognitive3D_Manager Instance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.cognitive3d.c3d-sdk",
-	"version": "2.1.0",
+	"version": "2.1.5",
 	"displayName": "Cognitive3D Unity SDK",
 	"description": "Analytics Platform for VR/AR/MR",
 	"unity": "2021.3",


### PR DESCRIPTION
# Description

Changes for release of Unity SDK 2.1.5:
- Fixed multiple code issues identified by the Unity Project Auditor
- Corrected the duration value for the unloaded scene event when transitioning from a non-tracking scene to a tracking scene
- Fixed an issue where dynamics were not uploading correctly when triggered from the Inspector
- Added a validation item to ensure the Hand Tracking option is enabled in OpenXR settings for Vive-OpenXR
- Forced recording of boundary shape and tracking space data on level load, even when the values remain unchanged.
- Improved boundary initialization by creating the boundary string builder once at session start, even if boundary points aren’t available after the initial 1-second wait
- Fixed a minor memory leak in Unity 2021 related to Segment’s open web requests
- Fixed an issue where dynamic upload cancellation was not being carried forward as expected

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
- [x] I have asked GitHub Copilot to review this PR
