### PR TITLE
OpenXR Hand and Controller Tracking Consistency Improvement

### DIFF
--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -815,7 +815,8 @@ namespace Cognitive3D
                     {
                         if (handDevices[0].TryGetFeatureValue(CommonUsages.deviceRotation, out Quaternion rot))
                         {
-                            return rot;
+                            var offsetRot = Quaternion.Euler(90, 0, 0);
+                            return rot * offsetRot;
                         }
                     }
                     break;

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.XR;
 
@@ -119,7 +118,7 @@ namespace Cognitive3D
                 return CommonDynamicMesh.ViveController;
             }
             if (xrDeviceName.Equals("Oculus Touch Controller - Left")
-                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight == false))
+                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && !isRight))
             {
                 string oculusHeadsetType = "";
     #if C3D_OCULUS
@@ -139,7 +138,7 @@ namespace Cognitive3D
                 }
             }
             if (xrDeviceName.Equals("Oculus Touch Controller - Right")
-                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight == true))
+                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight))
             {
                 string oculusHeadsetType = "";
     #if C3D_OCULUS
@@ -159,15 +158,14 @@ namespace Cognitive3D
                 }
             }
             if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
-                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == false)
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && !isRight)
                 || xrDeviceName.Contains("WVR_CR_Left"))
             {
                 return CommonDynamicMesh.ViveFocusControllerLeft;
             }
-            if ((xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
-                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == true)
+            if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight)
                 || xrDeviceName.Contains("WVR_CR_Right"))
-                && isRight)
             {
                 return CommonDynamicMesh.ViveFocusControllerRight;
             }
@@ -191,13 +189,13 @@ namespace Cognitive3D
             {
                 return CommonDynamicMesh.PicoNeo3ControllerRight;
             }
-            if (xrDeviceName.Equals("PICO Controller-Left")
-                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == false))
+            if ((xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && !isRight)
+                || xrDeviceName.Equals("PICO Controller-Left"))
             {
                 return CommonDynamicMesh.PicoNeo4ControllerLeft;
             }
-            if (xrDeviceName.Equals("PICO Controller-Right")
-                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == true))
+            if ((xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight)
+                || xrDeviceName.Equals("PICO Controller-Right"))
             {
                 return CommonDynamicMesh.PicoNeo4ControllerRight;
             }
@@ -221,7 +219,7 @@ namespace Cognitive3D
             }
 #endif
             if (xrDeviceName.Equals("Oculus Touch Controller - Left")
-                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight == false))
+                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && !isRight))
             {
                 string oculusHeadsetType = "";
 #if C3D_OCULUS
@@ -241,7 +239,7 @@ namespace Cognitive3D
                 }
             }
             if (xrDeviceName.Equals("Oculus Touch Controller - Right")
-                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight == true))
+                || (xrDeviceName.Equals("Oculus Touch Controller OpenXR") && isRight))
             {
                 string oculusHeadsetType = "";
 #if C3D_OCULUS
@@ -262,13 +260,13 @@ namespace Cognitive3D
             }
             if (xrDeviceName.Contains("OpenVR Controller(WindowsMR")
                 || xrDeviceName.Equals("Windows MR Controller OpenXR")
-                && isRight == false)
+                && !isRight)
             {
                 return ControllerDisplayType.windows_mixed_reality_controller_left;
             }
             if (xrDeviceName.Contains("OpenVR Controller(WindowsMR")
                 || xrDeviceName.Equals("Windows MR Controller OpenXR")
-                && isRight == true)
+                && !isRight)
             {
                 return ControllerDisplayType.windows_mixed_reality_controller_right;
             }
@@ -280,24 +278,24 @@ namespace Cognitive3D
             {
                 return ControllerDisplayType.pico_neo_3_eye_controller_right;
             }
-            if (xrDeviceName.Equals("PICO Controller-Left")
-                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == false))
+            if ((xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && !isRight)
+                || xrDeviceName.Equals("PICO Controller-Left"))
             {
                 return ControllerDisplayType.pico_neo_4_eye_controller_left;
             }
-            if (xrDeviceName.Equals("PICO Controller-Right")
-                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == true))
+            if ((xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight)
+                || xrDeviceName.Equals("PICO Controller-Right"))
             {
                 return ControllerDisplayType.pico_neo_4_eye_controller_right;
             }
             if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
-                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == false)
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && !isRight)
                 || xrDeviceName.Contains("WVR_CR_Left"))
             {
                 return ControllerDisplayType.vive_focus_controller_left;
             }
             if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
-                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == true)
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight)
                 || xrDeviceName.Contains("WVR_CR_Right"))
             {
                 return ControllerDisplayType.vive_focus_controller_right;
@@ -516,7 +514,6 @@ namespace Cognitive3D
             // Fetch all available XRHandSubsystems
             var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
             SubsystemManager.GetSubsystems(subsystems);
-
 
             foreach (var subsystem in subsystems)
             {

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -113,8 +113,8 @@ namespace Cognitive3D
 
         internal static CommonDynamicMesh GetControllerMeshName(string xrDeviceName, bool isRight)
         {
-            var vivePatterns = new[] { "Vive Wand", "Vive. Controller MV", "VIVE Focus 3 Controller OpenXR" };
-            if (vivePatterns.Any(p => xrDeviceName.Contains(p)) || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
+            if (xrDeviceName.Contains("Vive Wand")
+                || xrDeviceName.Contains("Vive. Controller MV"))
             {
                 return CommonDynamicMesh.ViveController;
             }
@@ -158,15 +158,14 @@ namespace Cognitive3D
                     return CommonDynamicMesh.OculusQuestTouchRight;
                 }
             }
-            if ((xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR")
+            if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == false)
                 || xrDeviceName.Contains("WVR_CR_Left"))
-                && !isRight)
             {
                 return CommonDynamicMesh.ViveFocusControllerLeft;
             }
             if ((xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR")
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == true)
                 || xrDeviceName.Contains("WVR_CR_Right"))
                 && isRight)
             {
@@ -192,11 +191,13 @@ namespace Cognitive3D
             {
                 return CommonDynamicMesh.PicoNeo3ControllerRight;
             }
-            if (xrDeviceName.Equals("PICO Controller-Left"))
+            if (xrDeviceName.Equals("PICO Controller-Left")
+                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == false))
             {
                 return CommonDynamicMesh.PicoNeo4ControllerLeft;
             }
-            if (xrDeviceName.Equals("PICO Controller-Right"))
+            if (xrDeviceName.Equals("PICO Controller-Right")
+                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == true))
             {
                 return CommonDynamicMesh.PicoNeo4ControllerRight;
             }
@@ -207,8 +208,8 @@ namespace Cognitive3D
         //used by controller input tracker to determine how to record input names
         internal static ControllerDisplayType GetControllerPopupName(string xrDeviceName, bool isRight)
         {
-            var vivePatterns = new[] { "Vive Wand", "Vive. Controller MV", "VIVE Focus 3 Controller OpenXR" };
-            if (vivePatterns.Any(p => xrDeviceName.Contains(p)) || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
+            if (xrDeviceName.Contains("Vive Wand")
+                || xrDeviceName.Contains("Vive. Controller MV"))
             {
                 return ControllerDisplayType.vive_controller;
             }
@@ -279,23 +280,25 @@ namespace Cognitive3D
             {
                 return ControllerDisplayType.pico_neo_3_eye_controller_right;
             }
-            if (xrDeviceName.Equals("PICO Controller-Left"))
+            if (xrDeviceName.Equals("PICO Controller-Left")
+                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == false))
             {
                 return ControllerDisplayType.pico_neo_4_eye_controller_left;
             }
-            if (xrDeviceName.Equals("PICO Controller-Right"))
+            if (xrDeviceName.Equals("PICO Controller-Right")
+                || (xrDeviceName.Equals("PICO4 Touch Controller OpenXR") && isRight == true))
             {
                 return ControllerDisplayType.pico_neo_4_eye_controller_right;
             }
-            if ((xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR")
-                || xrDeviceName.Contains("WVR_CR_Left")))
+            if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Left")
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == false)
+                || xrDeviceName.Contains("WVR_CR_Left"))
             {
                 return ControllerDisplayType.vive_focus_controller_left;
             }
-            if ((xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR")
-                || xrDeviceName.Contains("WVR_CR_Right")))
+            if (xrDeviceName.Equals("OpenVR Controller(vive_cosmos_controller) - Right")
+                || ((xrDeviceName.Equals("HTC Vive Controller OpenXR") || xrDeviceName.Contains("VIVE Focus 3 Controller OpenXR")) && isRight == true)
+                || xrDeviceName.Contains("WVR_CR_Right"))
             {
                 return ControllerDisplayType.vive_focus_controller_right;
             }

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.XR;
 
@@ -112,9 +113,8 @@ namespace Cognitive3D
 
         internal static CommonDynamicMesh GetControllerMeshName(string xrDeviceName, bool isRight)
         {
-            if (xrDeviceName.Contains("Vive Wand")
-                || xrDeviceName.Contains("Vive. Controller MV")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
+            var vivePatterns = new[] { "Vive Wand", "Vive. Controller MV", "VIVE Focus 3 Controller OpenXR" };
+            if (vivePatterns.Any(p => xrDeviceName.Contains(p)) || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
             {
                 return CommonDynamicMesh.ViveController;
             }
@@ -207,9 +207,8 @@ namespace Cognitive3D
         //used by controller input tracker to determine how to record input names
         internal static ControllerDisplayType GetControllerPopupName(string xrDeviceName, bool isRight)
         {
-            if (xrDeviceName.Contains("Vive Wand")
-                || xrDeviceName.Contains("Vive. Controller MV")
-                || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
+            var vivePatterns = new[] { "Vive Wand", "Vive. Controller MV", "VIVE Focus 3 Controller OpenXR" };
+            if (vivePatterns.Any(p => xrDeviceName.Contains(p)) || xrDeviceName.Equals("HTC Vive Controller OpenXR"))
             {
                 return ControllerDisplayType.vive_controller;
             }
@@ -508,38 +507,33 @@ namespace Cognitive3D
                 return InputType.None;
             }
 #elif C3D_DEFAULT
-    #if COGNITIVE3D_INCLUDE_XR_HANDS
-            UnityEngine.XR.Hands.XRHandSubsystem activeHandSubsystem = null;
-
-            // Fetch all available XRHandSubsystems
-            var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
-            SubsystemManager.GetSubsystems(subsystems);
-
-            foreach (var subsystem in subsystems)
-            {
-                if (subsystem.running)
-                {
-                    activeHandSubsystem = subsystem;
-                    break;
-                }
-            }
-
-            if (activeHandSubsystem != null)
-            {
-                if (activeHandSubsystem.leftHand.isTracked || activeHandSubsystem.rightHand.isTracked)
-                {
-                    return InputType.Hand;
-                }
-            }
-    #endif
-
             List<InputDevice> devices = new List<InputDevice>();
-            InputDevices.GetDevices(devices);
-            foreach (var device in devices)
+
+            // Check for controllers first - they take priority when actively tracked
+            InputDevices.GetDevicesWithCharacteristics(
+                InputDeviceCharacteristics.Controller | InputDeviceCharacteristics.HeldInHand,
+                devices);
+
+            if (devices.Count > 0 && devices[0].isValid)
             {
-                if ((device.characteristics & InputDeviceCharacteristics.Controller) != 0)
+                // Verify controller is actually being tracked
+                if (devices[0].TryGetFeatureValue(CommonUsages.isTracked, out bool isTracked) && isTracked)
                 {
                     return InputType.Controller;
+                }
+            }
+
+            // Check for hand tracking if no active controllers
+            devices.Clear();
+            InputDevices.GetDevicesWithCharacteristics(
+                InputDeviceCharacteristics.HandTracking, devices);
+
+            if (devices.Count > 0 && devices[0].isValid)
+            {
+                // Verify hand is actually being tracked
+                if (devices[0].TryGetFeatureValue(CommonUsages.isTracked, out bool isTracked) && isTracked)
+                {
+                    return InputType.Hand;
                 }
             }
 
@@ -658,28 +652,21 @@ namespace Cognitive3D
             {
                 case InputType.Controller:
                     return GetDefaultNodePosition(node);
-
-#if COGNITIVE3D_INCLUDE_XR_HANDS
                 case InputType.Hand:
-                    var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
-                    SubsystemManager.GetSubsystems(subsystems);
-
-                    foreach (var subsystem in subsystems)
+                    List<InputDevice> handDevices = new List<InputDevice>();
+                    InputDevices.GetDevicesWithCharacteristics(
+                        InputDeviceCharacteristics.HandTracking | 
+                        (node == XRNode.RightHand ? InputDeviceCharacteristics.Right : InputDeviceCharacteristics.Left),
+                        handDevices);
+                    
+                    if (handDevices.Count > 0 && handDevices[0].isValid)
                     {
-                        if (!subsystem.running) continue;
-
-                        var hand = node == XRNode.RightHand ? subsystem.rightHand : subsystem.leftHand;
-                        if (hand.isTracked)
+                        if (handDevices[0].TryGetFeatureValue(CommonUsages.devicePosition, out Vector3 pos))
                         {
-                            var wrist = hand.GetJoint(UnityEngine.XR.Hands.XRHandJointID.Wrist);
-                            if (wrist.TryGetPose(out var pose))
-                            {
-                                return pose.position;
-                            }
+                            return pos;
                         }
                     }
                     break;
-#endif
             }
 #endif
             // Default fallback for retrieving controller positions
@@ -817,28 +804,21 @@ namespace Cognitive3D
             {
                 case InputType.Controller:
                     return GetDefaultNodeRotation(node);
-
-    #if COGNITIVE3D_INCLUDE_XR_HANDS
                 case InputType.Hand:
-                    var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
-                    SubsystemManager.GetSubsystems(subsystems);
+                    List<InputDevice> handDevices = new List<InputDevice>();
+                    InputDevices.GetDevicesWithCharacteristics(
+                        InputDeviceCharacteristics.HandTracking |
+                        (node == XRNode.RightHand ? InputDeviceCharacteristics.Right : InputDeviceCharacteristics.Left),
+                        handDevices);
 
-                    foreach (var subsystem in subsystems)
+                    if (handDevices.Count > 0 && handDevices[0].isValid)
                     {
-                        if (!subsystem.running) continue;
-
-                        var hand = node == XRNode.RightHand ? subsystem.rightHand : subsystem.leftHand;
-                        if (hand.isTracked)
+                        if (handDevices[0].TryGetFeatureValue(CommonUsages.deviceRotation, out Quaternion rot))
                         {
-                            var wrist = hand.GetJoint(UnityEngine.XR.Hands.XRHandJointID.Wrist);
-                            if (wrist.TryGetPose(out var pose))
-                            {
-                                return pose.rotation;
-                            }
+                            return rot;
                         }
                     }
                     break;
-    #endif
             }
 #endif
             // Default fallback for retrieving controller rotations

--- a/Runtime/Internal/InputUtil.cs
+++ b/Runtime/Internal/InputUtil.cs
@@ -507,6 +507,32 @@ namespace Cognitive3D
                 return InputType.None;
             }
 #elif C3D_DEFAULT
+    #if COGNITIVE3D_INCLUDE_XR_HANDS
+            UnityEngine.XR.Hands.XRHandSubsystem activeHandSubsystem = null;
+
+            // Fetch all available XRHandSubsystems
+            var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
+            SubsystemManager.GetSubsystems(subsystems);
+
+
+            foreach (var subsystem in subsystems)
+            {
+                if (subsystem.running)
+
+                {
+                    activeHandSubsystem = subsystem;
+                    break;
+                }
+            }
+
+            if (activeHandSubsystem != null)
+            {
+                if (activeHandSubsystem.leftHand.isTracked || activeHandSubsystem.rightHand.isTracked)
+                {
+                    return InputType.Hand;
+                }
+            }
+    #endif
             List<InputDevice> devices = new List<InputDevice>();
 
             // Check for controllers first - they take priority when actively tracked
@@ -666,6 +692,25 @@ namespace Cognitive3D
                             return pos;
                         }
                     }
+    #if COGNITIVE3D_INCLUDE_XR_HANDS
+                    var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
+                    SubsystemManager.GetSubsystems(subsystems);
+
+                    foreach (var subsystem in subsystems)
+                    {
+                        if (!subsystem.running) continue;
+
+                        var hand = node == XRNode.RightHand ? subsystem.rightHand : subsystem.leftHand;
+                        if (hand.isTracked)
+                        {
+                            var wrist = hand.GetJoint(UnityEngine.XR.Hands.XRHandJointID.Wrist);
+                            if (wrist.TryGetPose(out var pose))
+                            {
+                                return pose.position;
+                            }
+                        }
+                    }
+    #endif
                     break;
             }
 #endif
@@ -819,6 +864,25 @@ namespace Cognitive3D
                             return rot * offsetRot;
                         }
                     }
+    #if COGNITIVE3D_INCLUDE_XR_HANDS
+                    var subsystems = new List<UnityEngine.XR.Hands.XRHandSubsystem>();
+                    SubsystemManager.GetSubsystems(subsystems);
+
+                    foreach (var subsystem in subsystems)
+                    {
+                        if (!subsystem.running) continue;
+
+                        var hand = node == XRNode.RightHand ? subsystem.rightHand : subsystem.leftHand;
+                        if (hand.isTracked)
+                        {
+                            var wrist = hand.GetJoint(UnityEngine.XR.Hands.XRHandJointID.Wrist);
+                            if (wrist.TryGetPose(out var pose))
+                            {
+                                return pose.rotation;
+                            }
+                        }
+                    }
+    #endif
                     break;
             }
 #endif


### PR DESCRIPTION
# Description

The following changes are made to fix inconsistent hand-tracking data in OpenXR, with a focus on Vive OpenXR.
- Added the generic OpenXR API to capture hand position and rotation
- Applied a rotation offset to OpenXR hand data to fix a 90° offset issue
- Kept XR Hands support for Meta and Pico headsets
- Updated controller display types to include the names returned by OpenXR for Vive Focus and Pico 4 controllers

Linear Issue ID(s) (If applicable): SDK-349

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
- [x] I have asked GitHub Copilot to review this PR
