### PR TITLE
HarmonEyes support

### DIFF
--- a/Editor/EditorCore.cs
+++ b/Editor/EditorCore.cs
@@ -1111,6 +1111,17 @@ namespace Cognitive3D
             }
         }
 
+        private static Texture2D _eyeTrackingIcon;
+        public static Texture2D EyeTrackingIcon
+        {
+            get
+            {
+                if (_eyeTrackingIcon == null)
+                    _eyeTrackingIcon = Resources.Load<Texture2D>("Features/Icons/eye-tracking");
+                return _eyeTrackingIcon;
+            }
+        }
+
         private static Texture2D _sensorIcon;
         public static Texture2D SensorIcon
         {

--- a/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs
+++ b/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace Cognitive3D
+{
+    internal class EyeTrackingDetailGUI : IFeatureDetailGUI
+    {
+        const string HarmonEyesDefine = "C3D_HARMONEYES";
+
+        public void OnGUI()
+        {
+            GUILayout.BeginHorizontal();
+            {
+                GUILayout.Label("Eye Tracking", EditorCore.styles.FeatureTitle);
+
+                float iconSize = EditorGUIUtility.singleLineHeight;
+                Rect iconRect = GUILayoutUtility.GetRect(iconSize, iconSize, GUILayout.Width(iconSize), GUILayout.Height(iconSize));
+
+                GUIContent buttonContent = new GUIContent(EditorCore.ExternalIcon, "Open Gaze & Fixations documentation");
+                if (GUI.Button(iconRect, buttonContent, EditorCore.styles.InfoButton))
+                {
+                    Application.OpenURL("https://docs.cognitive3d.com/unity/gaze-fixations/");
+                }
+
+                GUILayout.FlexibleSpace(); // Push content to the left
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.Label(
+                "Gaze and fixations are captured automatically when the platform SDK supports eye tracking. No component needed, just enable eye tracking on the device.",
+                EditorStyles.wordWrappedLabel
+            );
+
+            EditorGUILayout.Space(15);
+
+            DrawHarmonEyesSection();
+        }
+
+        private void DrawHarmonEyesSection()
+        {
+            GUILayout.Label("HarmonEyes", EditorCore.styles.FeatureTitle);
+            GUILayout.Label(
+                "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention, Mental Readiness) as sensors. Complete both steps.",
+                EditorStyles.wordWrappedLabel
+            );
+
+            EditorGUILayout.Space(10);
+
+            bool defineSet = EditorCore.GetPlayerDefines().Contains(HarmonEyesDefine);
+
+            // Step 1: scripting define symbol
+            GUILayout.Label("1. Scripting define symbol", EditorCore.styles.FeatureTitle);
+            GUILayout.Label("Adds the C3D_HARMONEYES define so the HarmonEyes integration compiles.", EditorStyles.wordWrappedLabel);
+
+            var defineLabel = defineSet ? "Remove C3D_HARMONEYES" : "Add C3D_HARMONEYES";
+            if (GUILayout.Button(defineLabel, GUILayout.Height(30)))
+            {
+                if (defineSet)
+                {
+                    EditorCore.RemoveDefine(HarmonEyesDefine);
+                }
+                else
+                {
+                    EditorCore.SetPlayerDefine(HarmonEyesDefine);
+                }
+            }
+
+            if (!defineSet)
+            {
+                EditorGUILayout.HelpBox("Add only after the HarmonEyes SDK is imported into your project.", MessageType.Warning);
+            }
+
+            EditorGUILayout.Space(10);
+
+            // Step 2: add the component to the manager prefab
+            GUILayout.Label("2. Add to Cognitive3D_Manager prefab", EditorCore.styles.FeatureTitle);
+            GUILayout.Label("Adds the HarmonEyes Tracking component to the Cognitive3D_Manager prefab to record the metrics.", EditorStyles.wordWrappedLabel);
+
+            EditorGUI.BeginDisabledGroup(!defineSet);
+            var btnLabel = FeatureLibrary.TryGetComponent<Cognitive3D.Components.HarmonEyesTracking>() ? "Remove HarmonEyes Tracking" : "Add HarmonEyes Tracking";
+            if (GUILayout.Button(btnLabel, GUILayout.Height(30)))
+            {
+                FeatureLibrary.AddOrRemoveComponent<Cognitive3D.Components.HarmonEyesTracking>();
+            }
+            EditorGUI.EndDisabledGroup();
+        }
+    }
+}

--- a/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs
+++ b/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs
@@ -61,7 +61,7 @@ namespace Cognitive3D
                 }
                 else
                 {
-                    EditorCore.SetPlayerDefine(HarmonEyesDefine);
+                    EditorCore.AddDefine(HarmonEyesDefine);
                 }
             }
 

--- a/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs.meta
+++ b/Editor/Features/FeatureGUIs/EyeTrackingDetailGUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 800af1f79b2b5d94caa29162df7c3a46

--- a/Editor/Features/FeatureLibrary.cs
+++ b/Editor/Features/FeatureLibrary.cs
@@ -155,12 +155,35 @@ namespace Cognitive3D
                 ),
                 new FeatureData(
                     false,
+                    "Eye Tracking",
+                    "Capture gaze and fixations, plus HarmonEyes metrics",
+                    EditorCore.EyeTrackingIcon,
+                    () =>
+                    {
+                        setFeatureIndex(5);
+                        SegmentAnalytics.TrackEvent("EyeTrackingWindow_Opened", "EyeTrackingWindow", "new");
+                    },
+                    new List<FeatureAction>
+                    {
+                        new FeatureAction(
+                            FeatureActionType.LinkTo,
+                            "Link to Gaze & Fixations documentation",
+                            () =>
+                            {
+                                Application.OpenURL("https://docs.cognitive3d.com/unity/gaze-fixations/");
+                            }
+                        )
+                    },
+                    new EyeTrackingDetailGUI()
+                ),
+                new FeatureData(
+                    false,
                     "Sensors",
                     "API reference and examples for recording custom sensors",
                     EditorCore.SensorIcon,
                     () =>
                     {
-                        setFeatureIndex(5);
+                        setFeatureIndex(6);
                         SegmentAnalytics.TrackEvent("SensorsWindow_Opened", "SensorsWindow", "new");
                     },
                     new List<FeatureAction>
@@ -183,7 +206,7 @@ namespace Cognitive3D
                     EditorCore.MultiplayerIcon,
                     () =>
                     {
-                        setFeatureIndex(6);
+                        setFeatureIndex(7);
                         SegmentAnalytics.TrackEvent("MultiplayerWindow_Opened", "MultiplayerWindow", "new");
                     },
                     new List<FeatureAction>
@@ -206,7 +229,7 @@ namespace Cognitive3D
                     EditorCore.MediaIcon,
                     () =>
                     {
-                        setFeatureIndex(7);
+                        setFeatureIndex(8);
                         SegmentAnalytics.TrackEvent("Media360Window_Opened", "Media360Window", "new");
                     },
                     new List<FeatureAction>
@@ -229,7 +252,7 @@ namespace Cognitive3D
                     EditorCore.AudioRecordingIcon,
                     () =>
                     {
-                        setFeatureIndex(8);
+                        setFeatureIndex(9);
                         SegmentAnalytics.TrackEvent("AudioRecordingWindow_Opened", "AudioRecordingWindow", "new");
                     },
                     new List<FeatureAction>
@@ -252,7 +275,7 @@ namespace Cognitive3D
                     EditorCore.RoomCaptureIcon,
                     () =>
                     {
-                        setFeatureIndex(9);
+                        setFeatureIndex(10);
                         SegmentAnalytics.TrackEvent("RoomCaptureWindow_Opened", "RoomCaptureWindow", "new");
                     },
                     new List<FeatureAction>

--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -33,7 +33,8 @@
         "Unity.XR.ARSubsystems",
         "Unity.XR.AndroidOpenXR",
         "Wave.Essence.ScenePerception",
-        "Google.XR.Extensions"
+        "Google.XR.Extensions",
+        "HarmonEyes.EyeTracking.Common"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/Components/HarmonEyesTracking.cs
+++ b/Runtime/Components/HarmonEyesTracking.cs
@@ -1,0 +1,149 @@
+using UnityEngine;
+
+namespace Cognitive3D.Components
+{
+    public class HarmonEyesTracking : AnalyticsComponentBase
+    {
+#if C3D_HARMONEYES
+        HarmonEyes.EyeTracking.Common.EyeTrackingAnalyzer subscribedAnalyzer;
+        bool isPolling;
+
+        protected override void OnSessionBegin()
+        {
+            Cognitive3D_Manager.OnPreSessionEnd += Cognitive3D_Manager_OnPreSessionEnd;
+            Cognitive3D_Manager.OnLevelLoaded += Cognitive3D_Manager_OnLevelLoaded;
+            EnsureSubscription();
+        }
+
+        void Cognitive3D_Manager_OnLevelLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode, bool didChangeSceneId)
+        {
+            EnsureSubscription();
+        }
+
+        void Cognitive3D_Manager_OnTick()
+        {
+            EnsureSubscription();
+        }
+
+        /// <summary>
+        /// Reconciles subscription with whichever analyzer currently exists: subscribes when one
+        /// appears, re-binds when the per-scene instance is swapped, and polls on tick while none is available
+        /// </summary>
+        void EnsureSubscription()
+        {
+            HarmonEyes.EyeTracking.Common.EyeTrackingAnalyzer current = HarmonEyes.EyeTracking.Common.AnalyzeEyeTrackingData.Instance != null
+                ? HarmonEyes.EyeTracking.Common.AnalyzeEyeTrackingData.Instance.EyeTrackingAnalyzer
+                : null;
+
+            if (!ReferenceEquals(current, subscribedAnalyzer))
+            {
+                if (subscribedAnalyzer != null)
+                {
+                    RemoveHarmonEyesListeners(subscribedAnalyzer);
+                    subscribedAnalyzer = null;
+                }
+
+                if (current != null)
+                {
+                    AddHarmonEyesListeners(current);
+                    subscribedAnalyzer = current;
+                }
+            }
+
+            // Keep polling only while there's nothing to subscribe to.
+            SetPolling(subscribedAnalyzer == null);
+        }
+
+        void SetPolling(bool shouldPoll)
+        {
+            if (shouldPoll == isPolling) return;
+            isPolling = shouldPoll;
+            if (shouldPoll)
+            {
+                Cognitive3D_Manager.OnTick += Cognitive3D_Manager_OnTick;
+                Util.logWarning("HarmonEyesTracking: AnalyzeEyeTrackingData is not ready. Waiting for the instance before subscribing.");
+            }
+            else
+            {
+                Cognitive3D_Manager.OnTick -= Cognitive3D_Manager_OnTick;
+            }
+        }
+
+        void AddHarmonEyesListeners(HarmonEyes.EyeTracking.Common.EyeTrackingAnalyzer analyzer)
+        {
+            analyzer.OnAttentionResult += OnAttentionResult;
+            analyzer.OnFatigueResult += OnFatigueResult;
+            analyzer.OnMentalReadinessResult += OnMentalReadinessResult;
+            analyzer.OnMentalWorkloadResult += OnMentalWorkloadResult;
+        }
+
+        void RemoveHarmonEyesListeners(HarmonEyes.EyeTracking.Common.EyeTrackingAnalyzer analyzer)
+        {
+            analyzer.OnAttentionResult -= OnAttentionResult;
+            analyzer.OnFatigueResult -= OnFatigueResult;
+            analyzer.OnMentalReadinessResult -= OnMentalReadinessResult;
+            analyzer.OnMentalWorkloadResult -= OnMentalWorkloadResult;
+        }
+
+        void Cognitive3D_Manager_OnPreSessionEnd()
+        {
+            SetPolling(false);
+            if (subscribedAnalyzer != null)
+            {
+                RemoveHarmonEyesListeners(subscribedAnalyzer);
+                subscribedAnalyzer = null;
+            }
+            Cognitive3D_Manager.OnLevelLoaded -= Cognitive3D_Manager_OnLevelLoaded;
+            Cognitive3D_Manager.OnPreSessionEnd -= Cognitive3D_Manager_OnPreSessionEnd;
+        }
+
+        void OnAttentionResult(HarmonEyes.EyeTracking.Common.AttentionData result)
+        {
+            if (result == null) return;
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.attention_level", result.level);
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.attention_score", result.composite_score);
+        }
+
+        void OnFatigueResult(HarmonEyes.EyeTracking.Common.FatigueData result)
+        {
+            if (result == null) return;
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.fatigue_level", result.level);
+        }
+
+        void OnMentalReadinessResult(HarmonEyes.EyeTracking.Common.MentalReadinessData result)
+        {
+            if (result == null) return;
+
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.mental_readiness_low_percent", result.low_percentage);
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.mental_readiness_moderate_percent", result.moderate_percentage);
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.mental_readiness_high_percent", result.high_percentage);
+        }
+
+        void OnMentalWorkloadResult(HarmonEyes.EyeTracking.Common.MentalWorkloadData result)
+        {
+            if (result == null) return;
+            SensorRecorder.RecordDataPoint("c3d.harmoneyes.mental_workload_level", result.level);
+        }
+
+        public override string GetDescription()
+        {
+            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors";
+        }
+
+        public override bool GetWarning()
+        {
+            return FindFirstObjectByType<HarmonEyes.EyeTracking.Common.AnalyzeEyeTrackingData>() == null;
+        }
+#else
+        public override string GetDescription()
+        {
+            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors. Requires the HarmonEyes Unity SDK in your project and the C3D_HARMONEYES scripting define symbol to be set.";
+        }
+
+        public override bool GetWarning()
+        {
+            return true;
+        }
+#endif
+    }
+}

--- a/Runtime/Components/HarmonEyesTracking.cs
+++ b/Runtime/Components/HarmonEyesTracking.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 namespace Cognitive3D.Components
 {
+    [AddComponentMenu("Cognitive3D/Components/HarmonEyes Tracking")]
     public class HarmonEyesTracking : AnalyticsComponentBase
     {
 #if C3D_HARMONEYES
@@ -124,26 +125,24 @@ namespace Cognitive3D.Components
             if (result == null) return;
             SensorRecorder.RecordDataPoint("c3d.harmoneyes.mental_workload_level", result.level);
         }
-
-        public override string GetDescription()
-        {
-            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors";
-        }
-
-        public override bool GetWarning()
-        {
-            return FindFirstObjectByType<HarmonEyes.EyeTracking.Common.AnalyzeEyeTrackingData>() == null;
-        }
-#else
-        public override string GetDescription()
-        {
-            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors. Requires the HarmonEyes Unity SDK in your project and the C3D_HARMONEYES scripting define symbol to be set.";
-        }
-
-        public override bool GetWarning()
-        {
-            return true;
-        }
 #endif
+
+        public override string GetDescription()
+        {
+#if C3D_HARMONEYES
+            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors";
+#else
+            return "Records HarmonEyes cognitive-state metrics (Mental Workload, Fatigue, Attention and Mental Readiness) as sensors. Requires the HarmonEyes Unity SDK in your project and the C3D_HARMONEYES scripting define symbol to be set.";
+#endif
+        }
+
+        public override bool GetWarning()
+        {
+#if C3D_HARMONEYES
+            return false;
+#else
+            return true;
+#endif
+        }
     }
 }

--- a/Runtime/Components/HarmonEyesTracking.cs
+++ b/Runtime/Components/HarmonEyesTracking.cs
@@ -88,6 +88,22 @@ namespace Cognitive3D.Components
 
         void Cognitive3D_Manager_OnPreSessionEnd()
         {
+            CleanupSubscriptions();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            CleanupSubscriptions();
+        }
+        
+        void OnDestroy()
+        {
+            CleanupSubscriptions();
+        }
+
+        void CleanupSubscriptions()
+        {
             SetPolling(false);
             if (subscribedAnalyzer != null)
             {

--- a/Runtime/Components/HarmonEyesTracking.cs.meta
+++ b/Runtime/Components/HarmonEyesTracking.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0a6d64c076df7b64382433b1ad60f679


### PR DESCRIPTION
# Description

Adds **HarmonEyes** support: automatically records HarmonEyes' cognitive-state metrics as Cognitive3D sensors whenever both SDKs are running.

- New `HarmonEyesTracking` component records Mental Workload, Fatigue, Attention, and Mental Readiness as sensors
- Subscribes to the HarmonEyes analyzer on session begin, polls until it is ready, and re-binds across scene loads
- Gated behind the `C3D_HARMONEYES` scripting define; runtime asmdef references the HarmonEyes assembly
- New **Eye Tracking** panel in the Feature Builder to add the define and the component

Linear Issue ID(s) (If applicable): C3D-2095

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned this PR to myself in GitHub
- [x] I have assigned and notified Reviewers for this PR
- [x] I have asked GitHub Copilot to review this PR
