### PR TITLE
Report raw device signals; remove in-SDK device classification

### DIFF
--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -111,6 +111,11 @@
             "define": "COGNITIVE3D_AR_FOUNDATION_6_3_OR_NEWER"
         },
         {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_OPENXR"
+        },
+        {
             "name": "com.unity.xr.androidxr-openxr",
             "expression": "",
             "define": "COGNITIVE3D_ANDROIDXR_OPENXR"

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -29,7 +29,7 @@ namespace Cognitive3D
     [DefaultExecutionOrder(-50)]
     public class Cognitive3D_Manager : MonoBehaviour
     {
-        public static readonly string SDK_VERSION = "2.5.0";
+        public static readonly string SDK_VERSION = "2.6.0";
     
         private static Cognitive3D_Manager instance;
         public static Cognitive3D_Manager Instance
@@ -161,6 +161,9 @@ namespace Cognitive3D
             CognitiveStatics.Initialize();
 
 #if UNITY_WEBGL
+            //browsers expose no stable hardware identifier, so this id is session-scoped and
+            //will differ on every run. it must not be treated as device-persistent.
+            //c3d.device.platform_name reports WebGLPlayer, which is how a consumer can tell
             DeviceId = System.Guid.NewGuid().ToString();
 #else
             DeviceId = SystemInfo.deviceUniqueIdentifier;
@@ -341,10 +344,8 @@ namespace Cognitive3D
                 {
                     Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", activeLoader.name);
                 }
-                else
-                {
-                    Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", "null");
-                }
+                //when there is no active loader the property is omitted entirely.
+                //a placeholder string would be indistinguishable from a loader actually named that
             }
             SetSessionPropertyIfEmpty("c3d.app.inEditor", Application.isEditor);
             SetSessionProperty("c3d.version", SDK_VERSION);
@@ -363,20 +364,33 @@ namespace Cognitive3D
 #endregion
         }
 
+        /// <summary>
+        /// reports device properties exactly as the platform returns them.
+        /// these are raw signals - device category, family and runtime host are resolved
+        /// downstream from these values, never here
+        /// </summary>
         private void SendHardwareDataAsSessionProperty()
         {
-#if UNITY_WEBGL && !UNITY_EDITOR
-            SetSessionProperty("c3d.device.type", "Web");
-#else
+            //raw Unity DeviceType enum (Desktop, Handheld, Console, Unknown).
+            //this is a hardware fact and must not be replaced by a build-target constant
             SetSessionProperty("c3d.device.type", SystemInfo.deviceType.ToString());
-#endif
+            //raw RuntimePlatform enum (WindowsPlayer, Android, IPhonePlayer, WebGLPlayer, ...)
+            SetSessionProperty("c3d.device.platform_name", Application.platform.ToString());
             SetSessionProperty("c3d.device.cpu", SystemInfo.processorType);
             SetSessionProperty("c3d.device.model", SystemInfo.deviceModel);
             SetSessionProperty("c3d.device.gpu", SystemInfo.graphicsDeviceName);
+            SetSessionProperty("c3d.device.gpu.vendor", SystemInfo.graphicsDeviceVendor);
+            SetSessionProperty("c3d.device.gpu.vendor.id", SystemInfo.graphicsDeviceVendorID);
             SetSessionProperty("c3d.device.os", SystemInfo.operatingSystem);
+            //existing property, kept for compatibility. value is whole gigabytes, rounded
             SetSessionProperty("c3d.device.memory", Mathf.RoundToInt((float)SystemInfo.systemMemorySize / 1024));
+            //unrounded value exactly as the platform reports it, in megabytes
+            SetSessionProperty("c3d.device.memoryInMegabytes", SystemInfo.systemMemorySize);
+            SetSessionProperty("c3d.device.screen.width", Screen.width);
+            SetSessionProperty("c3d.device.screen.height", Screen.height);
             SetSessionProperty("c3d.deviceid", DeviceId);
             SetSessionProperty("c3d.device.hmd.type", UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head).name);
+            SendXRRuntimeDataAsSessionProperty();
 
             #region SDK_SPECIFIC
 #if C3D_STEAMVR2
@@ -386,7 +400,8 @@ namespace Cognitive3D
 #endif
 
 #if C3D_OCULUS
-        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString().Replace('_', ' '));
+        //raw enum name, underscores intact (for example Quest_3), matching what this SDK reads internally elsewhere
+        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString());
         SetSessionProperty("c3d.device.eyetracking.enabled", GameplayReferences.SDKSupportsEyeTracking);
         SetSessionProperty("c3d.app.sdktype", "Oculus");
 #elif C3D_PICOVR
@@ -428,6 +443,43 @@ namespace Cognitive3D
             #endregion
         }
 
+        /// <summary>
+        /// reports which XR runtime is servicing the app, verbatim.
+        /// this is the signal that distinguishes otherwise identical tethered PC setups
+        /// (for example a headset running through SteamVR versus through its own vendor runtime),
+        /// which the compile-time SDK symbol alone cannot express.
+        /// called from SendHardwareDataAsSessionProperty so it inherits the same hardware-data consent gate
+        /// </summary>
+        private void SendXRRuntimeDataAsSessionProperty()
+        {
+#if COGNITIVE3D_INCLUDE_OPENXR
+            //empty when the OpenXR package is installed but is not the active loader
+            if (!string.IsNullOrEmpty(UnityEngine.XR.OpenXR.OpenXRRuntime.name))
+            {
+                SetSessionProperty("c3d.app.openxr.runtime.name", UnityEngine.XR.OpenXR.OpenXRRuntime.name);
+                SetSessionProperty("c3d.app.openxr.runtime.version", UnityEngine.XR.OpenXR.OpenXRRuntime.version);
+            }
+#endif
+            List<UnityEngine.XR.XRInputSubsystem> inputSubsystems = new List<UnityEngine.XR.XRInputSubsystem>();
+#if UNITY_6000_0_OR_NEWER
+            SubsystemManager.GetSubsystems<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
+#else
+            SubsystemManager.GetInstances<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
+#endif
+            //descriptor ids are reported unmodified. multiple ids are joined with commas
+            //only because a session property value has to be a single scalar
+            string inputSubsystemIds = string.Empty;
+            foreach (UnityEngine.XR.XRInputSubsystem inputSubsystem in inputSubsystems)
+            {
+                if (inputSubsystem == null || inputSubsystem.subsystemDescriptor == null) { continue; }
+                if (inputSubsystemIds.Length > 0) { inputSubsystemIds += ","; }
+                inputSubsystemIds += inputSubsystem.subsystemDescriptor.id;
+            }
+            if (inputSubsystemIds.Length > 0)
+            {
+                SetSessionProperty("c3d.app.xr.inputsubsystems", inputSubsystemIds);
+            }
+        }
 
         /// <summary>
         /// registered to unity's OnSceneLoaded callback. sends outstanding data, then sets correct tracking scene id and refreshes dynamic object session manifest

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -386,8 +386,31 @@ namespace Cognitive3D
             SetSessionProperty("c3d.device.memory", Mathf.RoundToInt((float)SystemInfo.systemMemorySize / 1024));
             //unrounded value exactly as the platform reports it, in megabytes
             SetSessionProperty("c3d.device.memoryInMegabytes", SystemInfo.systemMemorySize);
-            SetSessionProperty("c3d.device.screen.width", Screen.width);
-            SetSessionProperty("c3d.device.screen.height", Screen.height);
+            //Screen.width/height are the game window - on a tethered headset that is the desktop
+            //mirror window, which the player can resize at any time. that is not a device fact,
+            //so the device properties report the native resolution of the display instead
+            int displayWidthInPixels = UnityEngine.Display.main.systemWidth;
+            int displayHeightInPixels = UnityEngine.Display.main.systemHeight;
+            if (displayWidthInPixels > 0 && displayHeightInPixels > 0)
+            {
+                SetSessionProperty("c3d.device.screen.width", displayWidthInPixels);
+                SetSessionProperty("c3d.device.screen.height", displayHeightInPixels);
+            }
+            //per-eye render target of the active XR display. this is scaled by
+            //XRSettings.eyeTextureResolutionScale, which the application sets, so it describes the
+            //application's configuration rather than the panel and is reported as an app property.
+            //XRSettings comes from the built-in XR module, the same one that supplies InputDevices
+            //below, so it needs no package or platform guard
+            if (UnityEngine.XR.XRSettings.isDeviceActive)
+            {
+                int eyeTextureWidthInPixels = UnityEngine.XR.XRSettings.eyeTextureWidth;
+                int eyeTextureHeightInPixels = UnityEngine.XR.XRSettings.eyeTextureHeight;
+                if (eyeTextureWidthInPixels > 0 && eyeTextureHeightInPixels > 0)
+                {
+                    SetSessionProperty("c3d.app.xr.eyetexture.width", eyeTextureWidthInPixels);
+                    SetSessionProperty("c3d.app.xr.eyetexture.height", eyeTextureHeightInPixels);
+                }
+            }
             SetSessionProperty("c3d.deviceid", DeviceId);
             SetSessionProperty("c3d.device.hmd.type", UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head).name);
             SendXRRuntimeDataAsSessionProperty();
@@ -452,7 +475,14 @@ namespace Cognitive3D
         /// </summary>
         private void SendXRRuntimeDataAsSessionProperty()
         {
-#if COGNITIVE3D_INCLUDE_OPENXR
+            //the OpenXR version define only proves the OpenXR package is in the project manifest.
+            //it says nothing about the build target. OpenXRRuntime is a thin managed wrapper over
+            //a native plugin, and that plugin only ships for Windows x64, macOS, Android and UWP -
+            //everywhere else the managed code still compiles and then fails at link or call time.
+            //the supported targets are listed rather than excluding the unsupported ones: if this
+            //list ever goes stale the cost is one missing property, whereas a stale exclusion list
+            //breaks the build on whichever platform was overlooked
+#if COGNITIVE3D_INCLUDE_OPENXR && (UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_ANDROID || UNITY_WSA)
             //empty when the OpenXR package is installed but is not the active loader
             if (!string.IsNullOrEmpty(UnityEngine.XR.OpenXR.OpenXRRuntime.name))
             {
@@ -472,6 +502,10 @@ namespace Cognitive3D
             foreach (UnityEngine.XR.XRInputSubsystem inputSubsystem in inputSubsystems)
             {
                 if (inputSubsystem == null || inputSubsystem.subsystemDescriptor == null) { continue; }
+                //stopped instances stay in this list until the loader deinitializes them, so a
+                //session started in that window would otherwise name a runtime that is not
+                //servicing it. if nothing is running the property is omitted entirely
+                if (!inputSubsystem.running) { continue; }
                 if (inputSubsystemIds.Length > 0) { inputSubsystemIds += ","; }
                 inputSubsystemIds += inputSubsystem.subsystemDescriptor.id;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.cognitive3d.c3d-sdk",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"displayName": "Cognitive3D Unity SDK",
 	"description": "Analytics Platform for VR/AR/MR",
 	"unity": "2021.3",


### PR DESCRIPTION
# Description

Device properties are now reported exactly as the platform returns them.

The guiding principle: **raw signals flow through the SDK unchanged; interpretation happens
downstream.** The SDK's job is to query the OS/runtime and report what it says. Deciding *what
kind of device* a session ran on — category, family, model generation, runtime host — is a
single downstream concern. When the SDK also does a bit of that classification, there are two
sources of truth, they disagree, and the SDK's copy is frozen into every already-recorded
session and can never be corrected.

This PR removes the places where the SDK was doing that classification, and adds the raw signals
that were missing as a result.

Linear Issue ID(s) (If applicable): tracked internally; this PR is attached to its issue manually.

## Removed in-SDK transformations

| # | Where | Was | Now |
|---|---|---|---|
| 1 | `Cognitive3D_Manager.cs`, `SendHardwareDataAsSessionProperty()` | `#if UNITY_WEBGL && !UNITY_EDITOR` sent the constant string `"Web"` as `c3d.device.type` | Always sends `SystemInfo.deviceType.ToString()` |
| 2 | same method, `#if C3D_OCULUS` | `OVRPlugin.GetSystemHeadsetType().ToString().Replace('_', ' ')` | `OVRPlugin.GetSystemHeadsetType().ToString()` — underscores intact |
| 3 | `Cognitive3D_Manager.cs`, `SetSessionProperties()` | With no active XR loader, sent the literal string `"null"` as `c3d.app.xrplugin` | Property is omitted entirely |
| 4 | `Cognitive3D_Manager.cs`, `Initialize()` | WebGL device id is a fresh `Guid` each run | Unchanged — documented in place |

Notes on each:

1. **`"Web"` was a build-target fact wearing a hardware label.** It told a consumer nothing about
   the machine, and it actively hid what `SystemInfo.deviceType` would have said. The runtime host
   is now derivable from the new `c3d.device.platform_name` (`WebGLPlayer`), which is the correct
   place for it — a separate axis from what the hardware is.
2. **`Quest 3` vs `Quest_3`.** Cosmetic rewriting means any consumer lookup table has to encode
   this SDK's formatting choice. Worth noting: the SDK *already* reads the raw underscored form
   internally — `InputUtil.GetControllerMeshName()` matches on `"Quest_3"` — so the transformed
   value was inconsistent with the SDK's own usage.
3. **`"null"` is a valid string.** Nothing downstream can distinguish it from a real loader named
   that. Absence is the honest encoding of absence. (The surrounding `if` already emitted nothing
   when XR Management itself is absent, so this makes the two "no loader" cases agree.)
4. **Not fixable.** Browsers expose no stable hardware identifier. Left as-is with a comment
   stating the id is session-scoped and must not be treated as device-persistent;
   `c3d.device.platform_name = WebGLPlayer` is how a consumer detects the case.

## Added raw signals

All in `SendHardwareDataAsSessionProperty()` unless noted.

| Property | Source | Notes |
|---|---|---|
| `c3d.device.platform_name` | `Application.platform.ToString()` | Raw `RuntimePlatform` enum. The single strongest signal for separating runtime host from hardware. |
| `c3d.device.screen.width` | `Screen.width` | Pixels. Key name matches the WebXR SDK's existing key. |
| `c3d.device.screen.height` | `Screen.height` | Pixels. Same. |
| `c3d.device.gpu.vendor` | `SystemInfo.graphicsDeviceVendor` | Key name matches the WebXR SDK's existing key. |
| `c3d.device.gpu.vendor.id` | `SystemInfo.graphicsDeviceVendorID` | Stable numeric vendor id. |
| `c3d.device.memoryInMegabytes` | `SystemInfo.systemMemorySize` | Unrounded, exactly as reported. See below. |
| `c3d.app.openxr.runtime.name` | `OpenXRRuntime.name` | New `SendXRRuntimeDataAsSessionProperty()`. Behind a new `COGNITIVE3D_INCLUDE_OPENXR` version define. |
| `c3d.app.openxr.runtime.version` | `OpenXRRuntime.version` | Same. |
| `c3d.app.xr.inputsubsystems` | `XRInputSubsystem` descriptor ids | Same. Ids verbatim, comma-joined only because a session property value must be a single scalar. |

**On memory.** `c3d.device.memory` is unchanged and still carries whole gigabytes
(`systemMemorySize / 1024`, rounded). That rounding is lossy — 5.7 GB and 6.4 GB both become 6 —
which forces consumers into tolerance bands when matching hardware. Rather than change a
long-standing property, this adds the unrounded megabyte value alongside it under a name that
states its unit. Existing consumers are unaffected.

**On the OpenXR runtime name.** This is the signal that distinguishes otherwise identical tethered
PC setups — the same headset reached through SteamVR's OpenXR runtime versus its vendor runtime
looks the same today, because the compile-time SDK symbol cannot express it and `C3D_STEAMVR2`
does not override `c3d.device.hmd.type` at all. `OpenXRRuntime.name` closes that gap without any
SDK-side inference.

**Privacy gate.** Every new property is emitted from inside `SendHardwareDataAsSessionProperty()`,
which is already called only when the privacy framework's hardware-data consent is granted. That
includes the two XR-runtime properties: `SendXRRuntimeDataAsSessionProperty()` is called from
within the gated method specifically so it inherits the gate, even though the pre-existing sibling
property `c3d.app.xrplugin` is not gated. Deliberately conservative.

## Deliberately NOT done

- **The `c3d.app.sdktype` table was not extended.** Android XR OpenXR, Google XR Extensions and AR
  Foundation 6.2+ builds currently fall through to `sdktype = "Default"`. That is a real gap, but
  the fix is not another compile-symbol-to-friendly-string mapping — that is the very pattern this
  PR is reducing. Those platforms are now identifiable from raw signals instead:
  `c3d.device.platform_name = Android`, plus `c3d.app.openxr.runtime.name` and
  `c3d.app.xr.inputsubsystems`. Flagged for follow-up so it is a decision, not an oversight.
- **`InputUtil` device-name matching was left alone.** It maps XR device names to controller mesh
  assets. That is a rendering decision the SDK has to make locally, and none of it is emitted as a
  session property — so it is not classification-in-the-wrong-place.
- **No key renames.** `c3d.device.memory` and `c3d.device.type` keep their names and namespaces.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**What breaks:** three property *values* change shape for consumers that pattern-match on them.
No keys were removed or renamed.

- WebGL sessions: `c3d.device.type` was always `"Web"`, now reports the actual
  `SystemInfo.deviceType` (typically `Desktop` or `Handheld`).
- Meta sessions: `c3d.device.hmd.type` changes from `"Quest 3"` to `"Quest_3"` (and equivalents).
- Sessions with XR Management present but no active loader: `c3d.app.xrplugin` is now absent
  rather than the string `"null"`.

Downstream consumers must be updated to accept these before this ships.

## How this was verified

Being precise about this, because it is easy to overstate.

**What was actually run:**

- `mcs` (Mono 6.12) parse/structural check of the modified `Cognitive3D_Manager.cs` across seven
  preprocessor permutations: no defines at all, `C3D_OCULUS`, `UNITY_WEBGL`,
  `COGNITIVE3D_INCLUDE_OPENXR`, `UNITY_6000_0_OR_NEWER`, and two combined sets. Zero
  parser/structural errors in every permutation. Type-resolution errors (`CS0246` and friends,
  from `UnityEngine` not being on the reference path) were filtered out, as expected.
- That filter was itself negative-controlled: a deliberately broken copy of the same file
  (one removed semicolon) was confirmed to produce `CS1525` and be caught. The check is not
  vacuously passing.
- `Runtime/Cognitive3D.asmdef` parsed as JSON after the new version define was added.
- Grepped the whole package for readers of the three changed properties, and for the version
  literal. No runtime, editor, or sample code reads any of these session properties back; the
  version string exists in exactly the two places, both updated.
- Confirmed against Unity's published API reference that `OpenXRRuntime.name` and
  `OpenXRRuntime.version` exist as public static strings.

**What was NOT run, and why:**

- **No Unity compile.** There is no Unity installation on the machine this was prepared on, and
  this repo has no CI, no test suite, and no build command. The parse check above is a real check
  but it is *not* a type check — it cannot confirm that `Screen.width`, `SystemInfo.graphicsDevice
  VendorID`, `Application.platform`, or `XRInputSubsystem.subsystemDescriptor.id` resolve.
- **No runtime session was captured.** Nothing here has been observed producing an actual property
  bag on real hardware.

**Reasoned, not verified — please check these specifically:**

- `XRInputSubsystem.subsystemDescriptor.id`. Unity's scripting reference for `XRInputSubsystem`
  omits the generic base's members entirely, so it does not confirm the property. The evidence is
  by symmetry: `Runtime/Components/OculusHardware.cs` already uses
  `XRDisplaySubsystem.subsystemDescriptor.id` and compiles today, and both subsystem types derive
  from the same `IntegratedSubsystem<T>` base where the property is defined. High confidence, not
  certainty.
- The `UNITY_6000_0_OR_NEWER` guard around `GetSubsystems` / `GetInstances` mirrors the existing
  guarded pair in `Runtime/Internal/BoundaryUtil.cs` exactly, so it is proven in this codebase —
  but only for the `XRInputSubsystem` type, which is what is used here too.
- Whether XR subsystems are guaranteed to be running at session-initialization time. If they are
  not, `c3d.app.xr.inputsubsystems` is simply omitted — the same graceful degradation
  `c3d.app.xrplugin` already has — so the failure mode is a missing property, not an error.
- `COGNITIVE3D_INCLUDE_OPENXR` gating. Adding a version define cannot break a project that lacks
  the package (the define is simply never set, and the guarded block never compiles), and
  `Unity.XR.OpenXR` was already in the asmdef's optional references. But this is the one change
  that touches the conditional-compilation surface, so it deserves a look.

## Checklist

- [x] My changes will not interrupt or disrupt automated build processes
- [x] I have checked all outgoing links (i.e. to documentation) for validity
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — **not done.** The three changed
      property values need a docs update before release; no integrator-facing API changed.
- [ ] My changes generate no new warnings — **cannot confirm without a Unity compile.**
- [ ] Any dependent changes have been merged and published in downstream modules — **not yet.**
      Downstream must accept the three changed values first.
- [x] I have assigned this PR to myself in GitHub
- [ ] I have assigned and notified Reviewers for this PR
- [ ] I have asked GitHub Copilot to review this PR
