### PR TITLE
Revert "Report raw device signals; remove in-SDK device classification"

### DIFF
--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -111,11 +111,6 @@
             "define": "COGNITIVE3D_AR_FOUNDATION_6_3_OR_NEWER"
         },
         {
-            "name": "com.unity.xr.openxr",
-            "expression": "",
-            "define": "COGNITIVE3D_INCLUDE_OPENXR"
-        },
-        {
             "name": "com.unity.xr.androidxr-openxr",
             "expression": "",
             "define": "COGNITIVE3D_ANDROIDXR_OPENXR"

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -29,7 +29,7 @@ namespace Cognitive3D
     [DefaultExecutionOrder(-50)]
     public class Cognitive3D_Manager : MonoBehaviour
     {
-        public static readonly string SDK_VERSION = "2.6.0";
+        public static readonly string SDK_VERSION = "2.5.0";
     
         private static Cognitive3D_Manager instance;
         public static Cognitive3D_Manager Instance
@@ -161,9 +161,6 @@ namespace Cognitive3D
             CognitiveStatics.Initialize();
 
 #if UNITY_WEBGL
-            //browsers expose no stable hardware identifier, so this id is session-scoped and
-            //will differ on every run. it must not be treated as device-persistent.
-            //c3d.device.platform_name reports WebGLPlayer, which is how a consumer can tell
             DeviceId = System.Guid.NewGuid().ToString();
 #else
             DeviceId = SystemInfo.deviceUniqueIdentifier;
@@ -344,8 +341,10 @@ namespace Cognitive3D
                 {
                     Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", activeLoader.name);
                 }
-                //when there is no active loader the property is omitted entirely.
-                //a placeholder string would be indistinguishable from a loader actually named that
+                else
+                {
+                    Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", "null");
+                }
             }
             SetSessionPropertyIfEmpty("c3d.app.inEditor", Application.isEditor);
             SetSessionProperty("c3d.version", SDK_VERSION);
@@ -364,56 +363,20 @@ namespace Cognitive3D
 #endregion
         }
 
-        /// <summary>
-        /// reports device properties exactly as the platform returns them.
-        /// these are raw signals - device category, family and runtime host are resolved
-        /// downstream from these values, never here
-        /// </summary>
         private void SendHardwareDataAsSessionProperty()
         {
-            //raw Unity DeviceType enum (Desktop, Handheld, Console, Unknown).
-            //this is a hardware fact and must not be replaced by a build-target constant
+#if UNITY_WEBGL && !UNITY_EDITOR
+            SetSessionProperty("c3d.device.type", "Web");
+#else
             SetSessionProperty("c3d.device.type", SystemInfo.deviceType.ToString());
-            //raw RuntimePlatform enum (WindowsPlayer, Android, IPhonePlayer, WebGLPlayer, ...)
-            SetSessionProperty("c3d.device.platform_name", Application.platform.ToString());
+#endif
             SetSessionProperty("c3d.device.cpu", SystemInfo.processorType);
             SetSessionProperty("c3d.device.model", SystemInfo.deviceModel);
             SetSessionProperty("c3d.device.gpu", SystemInfo.graphicsDeviceName);
-            SetSessionProperty("c3d.device.gpu.vendor", SystemInfo.graphicsDeviceVendor);
-            SetSessionProperty("c3d.device.gpu.vendor.id", SystemInfo.graphicsDeviceVendorID);
             SetSessionProperty("c3d.device.os", SystemInfo.operatingSystem);
-            //existing property, kept for compatibility. value is whole gigabytes, rounded
             SetSessionProperty("c3d.device.memory", Mathf.RoundToInt((float)SystemInfo.systemMemorySize / 1024));
-            //unrounded value exactly as the platform reports it, in megabytes
-            SetSessionProperty("c3d.device.memoryInMegabytes", SystemInfo.systemMemorySize);
-            //Screen.width/height are the game window - on a tethered headset that is the desktop
-            //mirror window, which the player can resize at any time. that is not a device fact,
-            //so the device properties report the native resolution of the display instead
-            int displayWidthInPixels = UnityEngine.Display.main.systemWidth;
-            int displayHeightInPixels = UnityEngine.Display.main.systemHeight;
-            if (displayWidthInPixels > 0 && displayHeightInPixels > 0)
-            {
-                SetSessionProperty("c3d.device.screen.width", displayWidthInPixels);
-                SetSessionProperty("c3d.device.screen.height", displayHeightInPixels);
-            }
-            //per-eye render target of the active XR display. this is scaled by
-            //XRSettings.eyeTextureResolutionScale, which the application sets, so it describes the
-            //application's configuration rather than the panel and is reported as an app property.
-            //XRSettings comes from the built-in XR module, the same one that supplies InputDevices
-            //below, so it needs no package or platform guard
-            if (UnityEngine.XR.XRSettings.isDeviceActive)
-            {
-                int eyeTextureWidthInPixels = UnityEngine.XR.XRSettings.eyeTextureWidth;
-                int eyeTextureHeightInPixels = UnityEngine.XR.XRSettings.eyeTextureHeight;
-                if (eyeTextureWidthInPixels > 0 && eyeTextureHeightInPixels > 0)
-                {
-                    SetSessionProperty("c3d.app.xr.eyetexture.width", eyeTextureWidthInPixels);
-                    SetSessionProperty("c3d.app.xr.eyetexture.height", eyeTextureHeightInPixels);
-                }
-            }
             SetSessionProperty("c3d.deviceid", DeviceId);
             SetSessionProperty("c3d.device.hmd.type", UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head).name);
-            SendXRRuntimeDataAsSessionProperty();
 
             #region SDK_SPECIFIC
 #if C3D_STEAMVR2
@@ -423,8 +386,7 @@ namespace Cognitive3D
 #endif
 
 #if C3D_OCULUS
-        //raw enum name, underscores intact (for example Quest_3), matching what this SDK reads internally elsewhere
-        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString());
+        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString().Replace('_', ' '));
         SetSessionProperty("c3d.device.eyetracking.enabled", GameplayReferences.SDKSupportsEyeTracking);
         SetSessionProperty("c3d.app.sdktype", "Oculus");
 #elif C3D_PICOVR
@@ -466,54 +428,6 @@ namespace Cognitive3D
             #endregion
         }
 
-        /// <summary>
-        /// reports which XR runtime is servicing the app, verbatim.
-        /// this is the signal that distinguishes otherwise identical tethered PC setups
-        /// (for example a headset running through SteamVR versus through its own vendor runtime),
-        /// which the compile-time SDK symbol alone cannot express.
-        /// called from SendHardwareDataAsSessionProperty so it inherits the same hardware-data consent gate
-        /// </summary>
-        private void SendXRRuntimeDataAsSessionProperty()
-        {
-            //the OpenXR version define only proves the OpenXR package is in the project manifest.
-            //it says nothing about the build target. OpenXRRuntime is a thin managed wrapper over
-            //a native plugin, and that plugin only ships for Windows x64, macOS, Android and UWP -
-            //everywhere else the managed code still compiles and then fails at link or call time.
-            //the supported targets are listed rather than excluding the unsupported ones: if this
-            //list ever goes stale the cost is one missing property, whereas a stale exclusion list
-            //breaks the build on whichever platform was overlooked
-#if COGNITIVE3D_INCLUDE_OPENXR && (UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_ANDROID || UNITY_WSA)
-            //empty when the OpenXR package is installed but is not the active loader
-            if (!string.IsNullOrEmpty(UnityEngine.XR.OpenXR.OpenXRRuntime.name))
-            {
-                SetSessionProperty("c3d.app.openxr.runtime.name", UnityEngine.XR.OpenXR.OpenXRRuntime.name);
-                SetSessionProperty("c3d.app.openxr.runtime.version", UnityEngine.XR.OpenXR.OpenXRRuntime.version);
-            }
-#endif
-            List<UnityEngine.XR.XRInputSubsystem> inputSubsystems = new List<UnityEngine.XR.XRInputSubsystem>();
-#if UNITY_6000_0_OR_NEWER
-            SubsystemManager.GetSubsystems<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
-#else
-            SubsystemManager.GetInstances<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
-#endif
-            //descriptor ids are reported unmodified. multiple ids are joined with commas
-            //only because a session property value has to be a single scalar
-            string inputSubsystemIds = string.Empty;
-            foreach (UnityEngine.XR.XRInputSubsystem inputSubsystem in inputSubsystems)
-            {
-                if (inputSubsystem == null || inputSubsystem.subsystemDescriptor == null) { continue; }
-                //stopped instances stay in this list until the loader deinitializes them, so a
-                //session started in that window would otherwise name a runtime that is not
-                //servicing it. if nothing is running the property is omitted entirely
-                if (!inputSubsystem.running) { continue; }
-                if (inputSubsystemIds.Length > 0) { inputSubsystemIds += ","; }
-                inputSubsystemIds += inputSubsystem.subsystemDescriptor.id;
-            }
-            if (inputSubsystemIds.Length > 0)
-            {
-                SetSessionProperty("c3d.app.xr.inputsubsystems", inputSubsystemIds);
-            }
-        }
 
         /// <summary>
         /// registered to unity's OnSceneLoaded callback. sends outstanding data, then sets correct tracking scene id and refreshes dynamic object session manifest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.cognitive3d.c3d-sdk",
-	"version": "2.6.0",
+	"version": "2.5.0",
 	"displayName": "Cognitive3D Unity SDK",
 	"description": "Analytics Platform for VR/AR/MR",
 	"unity": "2021.3",


### PR DESCRIPTION
Reverts the merge of #265. The raw device signal work is being taken off `develop` for now and will be re-landed as part of the 2.5.0 release.

The SDK version returns to **2.5.0** in both `package.json` and `SDK_VERSION`.

### Previous behaviour restored

- `c3d.device.type` is again the constant `"Web"` on WebGL builds
- `c3d.device.hmd.type` on Meta builds again rewrites underscores to spaces
- `c3d.app.xrplugin` is again sent as the literal string `"null"` when no XR loader is active

### Raw signals removed again

- `c3d.device.platform_name`
- `c3d.device.screen.width` / `.height`
- `c3d.device.gpu.vendor` / `.vendor.id`
- `c3d.device.memoryInMegabytes`
- `c3d.app.openxr.runtime.name` / `.version`, along with the OpenXR version define in `Runtime/Cognitive3D.asmdef`
- `c3d.app.xr.inputsubsystems`
- `c3d.app.xr.eyetexture.width` / `.height`

### Notes

- Done as a revert commit rather than a history rewrite, since `develop` is shared and published.
- `feature/raw-device-signals` is deliberately **retained** so none of this work is lost.
- Reverted with `-m 1`, so the unrelated Identify sample follow-up that also sits on `develop` is untouched. After this change the tree matches the pre-#265 baseline plus that commit, and nothing else.
