### PR TITLE
Report raw device signals; remove in-SDK device classification

### DIFF
--- a/Runtime/Cognitive3D.asmdef
+++ b/Runtime/Cognitive3D.asmdef
@@ -111,6 +111,11 @@
             "define": "COGNITIVE3D_AR_FOUNDATION_6_3_OR_NEWER"
         },
         {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "COGNITIVE3D_INCLUDE_OPENXR"
+        },
+        {
             "name": "com.unity.xr.androidxr-openxr",
             "expression": "",
             "define": "COGNITIVE3D_ANDROIDXR_OPENXR"

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -161,6 +161,9 @@ namespace Cognitive3D
             CognitiveStatics.Initialize();
 
 #if UNITY_WEBGL
+            //browsers expose no stable hardware identifier, so this id is session-scoped and
+            //will differ on every run. it must not be treated as device-persistent.
+            //c3d.device.platform_name reports WebGLPlayer, which is how a consumer can tell
             DeviceId = System.Guid.NewGuid().ToString();
 #else
             DeviceId = SystemInfo.deviceUniqueIdentifier;
@@ -341,10 +344,8 @@ namespace Cognitive3D
                 {
                     Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", activeLoader.name);
                 }
-                else
-                {
-                    Cognitive3D_Manager.SetSessionProperty("c3d.app.xrplugin", "null");
-                }
+                //when there is no active loader the property is omitted entirely.
+                //a placeholder string would be indistinguishable from a loader actually named that
             }
             SetSessionPropertyIfEmpty("c3d.app.inEditor", Application.isEditor);
             SetSessionProperty("c3d.version", SDK_VERSION);
@@ -363,20 +364,56 @@ namespace Cognitive3D
 #endregion
         }
 
+        /// <summary>
+        /// reports device properties exactly as the platform returns them.
+        /// these are raw signals - device category, family and runtime host are resolved
+        /// downstream from these values, never here
+        /// </summary>
         private void SendHardwareDataAsSessionProperty()
         {
-#if UNITY_WEBGL && !UNITY_EDITOR
-            SetSessionProperty("c3d.device.type", "Web");
-#else
+            //raw Unity DeviceType enum (Desktop, Handheld, Console, Unknown).
+            //this is a hardware fact and must not be replaced by a build-target constant
             SetSessionProperty("c3d.device.type", SystemInfo.deviceType.ToString());
-#endif
+            //raw RuntimePlatform enum (WindowsPlayer, Android, IPhonePlayer, WebGLPlayer, ...)
+            SetSessionProperty("c3d.device.platform_name", Application.platform.ToString());
             SetSessionProperty("c3d.device.cpu", SystemInfo.processorType);
             SetSessionProperty("c3d.device.model", SystemInfo.deviceModel);
             SetSessionProperty("c3d.device.gpu", SystemInfo.graphicsDeviceName);
+            SetSessionProperty("c3d.device.gpu.vendor", SystemInfo.graphicsDeviceVendor);
+            SetSessionProperty("c3d.device.gpu.vendor.id", SystemInfo.graphicsDeviceVendorID);
             SetSessionProperty("c3d.device.os", SystemInfo.operatingSystem);
+            //existing property, kept for compatibility. value is whole gigabytes, rounded
             SetSessionProperty("c3d.device.memory", Mathf.RoundToInt((float)SystemInfo.systemMemorySize / 1024));
+            //unrounded value exactly as the platform reports it, in megabytes
+            SetSessionProperty("c3d.device.memoryInMegabytes", SystemInfo.systemMemorySize);
+            //Screen.width/height are the game window - on a tethered headset that is the desktop
+            //mirror window, which the player can resize at any time. that is not a device fact,
+            //so the device properties report the native resolution of the display instead
+            int displayWidthInPixels = UnityEngine.Display.main.systemWidth;
+            int displayHeightInPixels = UnityEngine.Display.main.systemHeight;
+            if (displayWidthInPixels > 0 && displayHeightInPixels > 0)
+            {
+                SetSessionProperty("c3d.device.screen.width", displayWidthInPixels);
+                SetSessionProperty("c3d.device.screen.height", displayHeightInPixels);
+            }
+            //per-eye render target of the active XR display. this is scaled by
+            //XRSettings.eyeTextureResolutionScale, which the application sets, so it describes the
+            //application's configuration rather than the panel and is reported as an app property.
+            //XRSettings comes from the built-in XR module, the same one that supplies InputDevices
+            //below, so it needs no package or platform guard
+            if (UnityEngine.XR.XRSettings.isDeviceActive)
+            {
+                int eyeTextureWidthInPixels = UnityEngine.XR.XRSettings.eyeTextureWidth;
+                int eyeTextureHeightInPixels = UnityEngine.XR.XRSettings.eyeTextureHeight;
+                if (eyeTextureWidthInPixels > 0 && eyeTextureHeightInPixels > 0)
+                {
+                    SetSessionProperty("c3d.app.xr.eyetexture.width", eyeTextureWidthInPixels);
+                    SetSessionProperty("c3d.app.xr.eyetexture.height", eyeTextureHeightInPixels);
+                }
+            }
             SetSessionProperty("c3d.deviceid", DeviceId);
             SetSessionProperty("c3d.device.hmd.type", UnityEngine.XR.InputDevices.GetDeviceAtXRNode(UnityEngine.XR.XRNode.Head).name);
+            SendXRRuntimeDataAsSessionProperty();
 
             #region SDK_SPECIFIC
 #if C3D_STEAMVR2
@@ -386,7 +423,8 @@ namespace Cognitive3D
 #endif
 
 #if C3D_OCULUS
-        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString().Replace('_', ' '));
+        //raw enum name, underscores intact (for example Quest_3), matching what this SDK reads internally elsewhere
+        SetSessionProperty("c3d.device.hmd.type", OVRPlugin.GetSystemHeadsetType().ToString());
         SetSessionProperty("c3d.device.eyetracking.enabled", GameplayReferences.SDKSupportsEyeTracking);
         SetSessionProperty("c3d.app.sdktype", "Oculus");
 #elif C3D_PICOVR
@@ -428,6 +466,54 @@ namespace Cognitive3D
             #endregion
         }
 
+        /// <summary>
+        /// reports which XR runtime is servicing the app, verbatim.
+        /// this is the signal that distinguishes otherwise identical tethered PC setups
+        /// (for example a headset running through SteamVR versus through its own vendor runtime),
+        /// which the compile-time SDK symbol alone cannot express.
+        /// called from SendHardwareDataAsSessionProperty so it inherits the same hardware-data consent gate
+        /// </summary>
+        private void SendXRRuntimeDataAsSessionProperty()
+        {
+            //the OpenXR version define only proves the OpenXR package is in the project manifest.
+            //it says nothing about the build target. OpenXRRuntime is a thin managed wrapper over
+            //a native plugin, and that plugin only ships for Windows x64, macOS, Android and UWP -
+            //everywhere else the managed code still compiles and then fails at link or call time.
+            //the supported targets are listed rather than excluding the unsupported ones: if this
+            //list ever goes stale the cost is one missing property, whereas a stale exclusion list
+            //breaks the build on whichever platform was overlooked
+#if COGNITIVE3D_INCLUDE_OPENXR && (UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_ANDROID || UNITY_WSA)
+            //empty when the OpenXR package is installed but is not the active loader
+            if (!string.IsNullOrEmpty(UnityEngine.XR.OpenXR.OpenXRRuntime.name))
+            {
+                SetSessionProperty("c3d.app.openxr.runtime.name", UnityEngine.XR.OpenXR.OpenXRRuntime.name);
+                SetSessionProperty("c3d.app.openxr.runtime.version", UnityEngine.XR.OpenXR.OpenXRRuntime.version);
+            }
+#endif
+            List<UnityEngine.XR.XRInputSubsystem> inputSubsystems = new List<UnityEngine.XR.XRInputSubsystem>();
+#if UNITY_6000_0_OR_NEWER
+            SubsystemManager.GetSubsystems<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
+#else
+            SubsystemManager.GetInstances<UnityEngine.XR.XRInputSubsystem>(inputSubsystems);
+#endif
+            //descriptor ids are reported unmodified. multiple ids are joined with commas
+            //only because a session property value has to be a single scalar
+            string inputSubsystemIds = string.Empty;
+            foreach (UnityEngine.XR.XRInputSubsystem inputSubsystem in inputSubsystems)
+            {
+                if (inputSubsystem == null || inputSubsystem.subsystemDescriptor == null) { continue; }
+                //stopped instances stay in this list until the loader deinitializes them, so a
+                //session started in that window would otherwise name a runtime that is not
+                //servicing it. if nothing is running the property is omitted entirely
+                if (!inputSubsystem.running) { continue; }
+                if (inputSubsystemIds.Length > 0) { inputSubsystemIds += ","; }
+                inputSubsystemIds += inputSubsystem.subsystemDescriptor.id;
+            }
+            if (inputSubsystemIds.Length > 0)
+            {
+                SetSessionProperty("c3d.app.xr.inputsubsystems", inputSubsystemIds);
+            }
+        }
 
         /// <summary>
         /// registered to unity's OnSceneLoaded callback. sends outstanding data, then sets correct tracking scene id and refreshes dynamic object session manifest

--- a/Runtime/Scripts/Cognitive3D_Manager.cs
+++ b/Runtime/Scripts/Cognitive3D_Manager.cs
@@ -327,7 +327,7 @@ namespace Cognitive3D
         {
             SetSessionProperty("c3d.app.name", Application.productName);
             SetSessionProperty("c3d.app.version", Application.version);
-            SetSessionProperty("c3d.app.package", Application.identifier);
+            if (!string.IsNullOrEmpty(Application.identifier)) SetSessionProperty("c3d.app.package", Application.identifier);
             SetSessionProperty("c3d.app.engine.version", Application.unityVersion);
 
 #if XRPF


### PR DESCRIPTION
## What this does

The SDK reports device properties **exactly as the platform returns them**, and stops deciding
what a device *is*.

Two halves:

1. **New raw signals** — additional facts the OS/engine already exposes but that the SDK was not
   sending (GPU vendor, platform name, display resolution, per-eye render target, OpenXR runtime,
   active XR input subsystems, unrounded memory).
2. **Three in-SDK translations removed** — places where the SDK rewrote or invented a value before
   sending it.

### Why

Classifying a device (is it a headset? which family? which runtime is it on?) belongs in the
pipeline, not in the SDK. Two reasons:

- **A translation in the SDK is permanent.** Whatever the SDK sends is what every consumer sees
  forever; the raw value is gone. If a classification turns out to be wrong, fixing it means
  shipping a new SDK version and waiting for every customer to upgrade. Fixing it in the pipeline
  is a deploy, and it can be re-applied to existing sessions.
- **The SDK can't see enough to classify well.** It knows its own compile-time symbols and one or
  two strings; the enrichment service can combine signals across all SDKs and platforms and apply
  one consistent taxonomy. Right now the same physical headset can be labelled differently
  depending on which SDK reported it.

So: SDK reports facts, pipeline derives meaning.

## Ships with the 2.5.0 release

**No version bump here.** `package.json` and `SDK_VERSION` stay at `2.5.0`, matching `develop`.
This work is intended to go out as part of **#264 "Release 2.5.0"**, not as a release of its own.

## Behaviour changes for consumers

These three change values that are already being emitted today, so they are worth reading
explicitly rather than discovering later.

| Property | Before | After |
|---|---|---|
| `c3d.device.type` (WebGL builds only) | the hardcoded constant `"Web"` | the real `SystemInfo.deviceType` — `Desktop`, `Handheld`, `Console` or `Unknown` |
| `c3d.device.hmd.type` (Meta/Oculus builds only) | underscores rewritten to spaces, e.g. `Meta Quest 3` | the enum name as the platform returns it, underscores intact, e.g. `Meta_Quest_3` |
| `c3d.app.xrplugin` | the literal string `"null"` when no XR loader is active | **omitted entirely** when no loader is active |

**The backend already handles all three.** It scrubs the `"null"` placeholder, accepts both
`hmd.type` spellings, and does not read `c3d.device.type` for anything. Nothing downstream needs
to change for this to land — but a reviewer deserves the list rather than having to work it out.

On the third row specifically: `"null"` as a value is indistinguishable from a loader that is
genuinely named that, and it forces every consumer to special-case the string. An absent property
is unambiguous.

## New properties

Device facts:

- `c3d.device.platform_name` — `Application.platform` verbatim (`WindowsPlayer`, `Android`,
  `WebGLPlayer`, …). This is what lets a consumer tell WebGL apart now that `c3d.device.type`
  reports real hardware.
- `c3d.device.gpu.vendor`, `c3d.device.gpu.vendor.id`
- `c3d.device.screen.width`, `c3d.device.screen.height`
- `c3d.device.memoryInMegabytes`

Application/runtime facts:

- `c3d.app.openxr.runtime.name`, `c3d.app.openxr.runtime.version`
- `c3d.app.xr.inputsubsystems`
- `c3d.app.xr.eyetexture.width`, `c3d.app.xr.eyetexture.height`

`c3d.device.memory` is **unchanged** — still whole gigabytes, rounded. `memoryInMegabytes` is the
unrounded platform value alongside it, so nothing that already reads `c3d.device.memory` is
affected.

### Three details worth a look, since they are judgement calls

**Screen dimensions use `Display.main.systemWidth/Height`, not `Screen.width/height`.**
`Screen.*` is the game *window*. On a tethered headset that window is the desktop mirror window,
which the player can resize at any time — so two identical headsets reported different values
purely because of how their users had sized a window. `Display.main.system*` is the native display
resolution, which is a device fact. Both properties are omitted rather than sent as `0` if the
platform reports nothing.

**Eye texture is reported under `c3d.app.`, not `c3d.device.`** — it is scaled by
`XRSettings.eyeTextureResolutionScale`, which the *application* sets, so it describes the app's
configuration rather than the panel.

**The OpenXR query is guarded by a platform allowlist, not just the package define.** The new
`COGNITIVE3D_INCLUDE_OPENXR` version define only proves the OpenXR package is in the project
manifest; it says nothing about the build target. `OpenXRRuntime` is a managed wrapper over a
native plugin that only ships for Windows x64, macOS, Android and UWP — elsewhere the managed code
compiles and then fails at link/call time. The guard lists the supported targets rather than
excluding unsupported ones deliberately: a stale allowlist costs one missing property, a stale
exclusion list breaks the build on whichever platform was overlooked.

`c3d.app.xr.inputsubsystems` filters on `.running`. Stopped subsystem instances stay in the
manager's list until the loader deinitializes them, so without the filter a session started in
that window would name a runtime that is not actually servicing it. If nothing is running, the
property is omitted.

## History, so the branch name doesn't mislead

This exact content was merged to `develop` and then reverted. **The revert was solely so this
could be reviewed before landing — nothing was found wrong with it.** This PR re-applies it,
unchanged apart from keeping the version at `2.5.0`. The three follow-up fixes from the earlier
review round (display resolution, the OpenXR platform allowlist, the `.running` filter) are
included.

## Testing notes

Compile-only change to session-property reporting; there is no test suite in this repo. Worth
sanity-checking on whichever target you have handy that the new properties appear on a session
and that `c3d.app.xrplugin` is absent (not `"null"`) when no loader is active.

## Diff

2 files, +100 / −9. No version change, and nothing under `Samples~/`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
